### PR TITLE
Removes dependency on jsr305 from census-core.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,7 @@
 java_library(
     name = "census-core",
     srcs = glob(["core/java/com/google/census/*.java"]),
-    deps = ["@jsr305//jar"],
+    deps = [],
 )
 
 java_library(

--- a/core/java/com/google/census/CensusContextFactory.java
+++ b/core/java/com/google/census/CensusContextFactory.java
@@ -14,7 +14,6 @@
 package com.google.census;
 
 import java.nio.ByteBuffer;
-import javax.annotation.Nullable;
 
 /**
  * Factory class for {@link CensusContext}.
@@ -27,9 +26,9 @@ public abstract class CensusContextFactory {
    * should be based on the {@link CensusContext} protobuf representation.
    *
    * @param buffer on-the-wire representation of a {@link CensusContext}
-   * @return a {@link CensusContext} deserialized from {@code buffer}
+   * @return a {@link CensusContext} deserialized from {@code buffer}, or {@code null} if the input
+   *         is invalid
    */
-  @Nullable
   public abstract CensusContext deserialize(ByteBuffer buffer);
 
   /**


### PR DESCRIPTION
I split this off from #15 so that we can decide whether to remove the two dependencies independently.
