### PR TITLE
Add an interface that extends Closeable which cannot throw a checked exception.

### DIFF
--- a/core/java/com/google/instrumentation/common/NonThrowingCloseable.java
+++ b/core/java/com/google/instrumentation/common/NonThrowingCloseable.java
@@ -4,6 +4,17 @@ import java.io.Closeable;
 
 /**
  * An {@link Closeable} which cannot throw a checked exception.
+ *
+ * <p>This is useful because such a reversion otherwise requires the caller to catch the
+ * (impossible) Exception in the try-with-resources.
+ *
+ * <p>Example of usage:
+ *
+ * <pre>
+ *   try (NonThrowingAutoCloseable ctx = tryEnter()) {
+ *     ...
+ *   }
+ * </pre>
  */
 public interface NonThrowingCloseable extends Closeable {
   @Override

--- a/core/java/com/google/instrumentation/common/NonThrowingCloseable.java
+++ b/core/java/com/google/instrumentation/common/NonThrowingCloseable.java
@@ -1,0 +1,11 @@
+package com.google.instrumentation.common;
+
+import java.io.Closeable;
+
+/**
+ * An {@link Closeable} which cannot throw a checked exception.
+ */
+public interface NonThrowingCloseable extends Closeable {
+  @Override
+  void close();
+}


### PR DESCRIPTION
This helps with support for try-with-resource idiom.

Sample use case:
  try (NonThrowingAutoCloseable ctx = tryEnter()) {
    ...
  }