### PR TITLE
Make View.getStart() and View.getEnd() public

### DIFF
--- a/core/java/com/google/instrumentation/stats/View.java
+++ b/core/java/com/google/instrumentation/stats/View.java
@@ -65,14 +65,14 @@ public abstract class View {
     /**
      * Returns start timestamp for this aggregation.
      */
-    Timestamp getStart() {
+    public Timestamp getStart() {
       return start;
     }
 
     /**
      * Returns end timestamp for this aggregation.
      */
-    Timestamp getEnd() {
+    public Timestamp getEnd() {
       return end;
     }
 


### PR DESCRIPTION
These accessor methods need to be public for external code to properly serialize Views.