### PR TITLE
Downgrades default guava version to 19.0, and tests with guava 19.0, 20.0, and 21.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,14 @@ install:
         cd .. ;;
     esac
 
+# TODO(sebright) Turn on the deprecation warning after we upgrade to truth 0.31.
+# It undeprecates DoubleSubject.isEqualTo(Double).
+
 # TODO(sebright) Find a way to disable the "cast" warning only for Protocol Buffer generated code.
 script:
   - case "$BUILD" in
       "BAZEL")
-        bazel test ... --javacopt=-Werror --javacopt=-Xlint:all --javacopt=-Xlint:-cast ;;
+        bazel test ... --javacopt=-Werror --javacopt=-Xlint:all --javacopt=-Xlint:-cast --javacopt=-Xlint:-deprecation ;;
       "MVN")
         case "$TRAVIS_JDK_VERSION" in
           "openjdk6")

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,19 @@ language: java
 matrix:
   include:
   - jdk: openjdk6
-    env: BUILD=MVN
+    env: BUILD=MVN GUAVA_VERSION=19.0
 
   - jdk: oraclejdk7
-    env: BUILD=MVN STYLE_CHECK=google_checks.xml
+    env: BUILD=MVN GUAVA_VERSION=19.0 STYLE_CHECK=checkstyle_custom_checks.xml
+
+  - jdk: oraclejdk7
+    env: BUILD=MVN GUAVA_VERSION=21.0 STYLE_CHECK=google_checks.xml
 
   - jdk: oraclejdk8
-    env: BUILD=MVN STYLE_CHECK=google_checks.xml
+    env: BUILD=MVN GUAVA_VERSION=19.0 STYLE_CHECK=google_checks.xml
 
   - jdk: oraclejdk8
-    env: BUILD=MVN STYLE_CHECK=checkstyle_custom_checks.xml
+    env: BUILD=MVN GUAVA_VERSION=20.0 STYLE_CHECK=checkstyle_custom_checks.xml
 
   - jdk: oraclejdk8
     env: BUILD=BAZEL
@@ -53,8 +56,8 @@ script:
       "MVN")
         case "$TRAVIS_JDK_VERSION" in
           "openjdk6")
-            mvn verify -P java6 ;;
+            mvn verify -P java6 -Dguava.version=$GUAVA_VERSION ;;
           *)
-            mvn verify -Dcheckstyle.config=$STYLE_CHECK ;;
+            mvn verify -Dguava.version=$GUAVA_VERSION -Dcheckstyle.config=$STYLE_CHECK ;;
         esac
     esac

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,12 +16,12 @@ maven_jar(
 
 maven_jar(
     name = "guava",
-    artifact = "com.google.guava:guava:20.0",
+    artifact = "com.google.guava:guava:19.0",
 )
 
 maven_jar(
     name = "guava_testlib",
-    artifact = "com.google.guava:guava-testlib:20.0",
+    artifact = "com.google.guava:guava-testlib:19.0",
 )
 
 maven_jar(
@@ -41,7 +41,7 @@ maven_jar(
 
 maven_jar(
     name = "truth",
-    artifact = "com.google.truth:truth:0.31",
+    artifact = "com.google.truth:truth:0.30",
 )
 
 git_repository(

--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,15 @@
     <module>shared</module>
   </modules>
 
+  <properties>
+    <guava.version>19.0</guava.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>20.0</version>
+      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
This change also requires downgrading truth to 0.30.

See https://github.com/grpc/grpc-java/issues/2688#issuecomment-280205113 .  I tested with multiple `guava` versions by adding a Maven property for the version, because I couldn't find a way to specify the version of a dependency on the command line.  Let me know if there is a better way to test multiple versions.

/cc @zhangkun83 @dinooliva 