### PR TITLE
Modify serialize and deserialize methods to match the new tag encodings.

### DIFF
--- a/core/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
@@ -24,8 +24,14 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class StatsContextFactoryTest {
-  @Test(expected = IOException.class)
+  @Test
   public void testDeserializeEmpty() throws Exception {
     Stats.getStatsContextFactory().deserialize(new ByteArrayInputStream(new byte[0]));
+  }
+
+  @Test(expected = IOException.class)
+  public void testDeserializeWrongFormat() throws Exception {
+    // encoded tags should follow the format [tag_type key_len key_bytes value_len value_bytes]*
+    Stats.getStatsContextFactory().deserialize(new ByteArrayInputStream(new byte[1]));
   }
 }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsSerializer.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsSerializer.java
@@ -69,7 +69,7 @@ final class StatsSerializer {
       HashMap<String, String> tags = new HashMap<String, String>();
       int limit = buffer.limit();
       while (buffer.position() < limit) {
-        int type = (int) buffer.get();
+        int type = VarInt.getVarInt(buffer);
         switch (type) {
           case TYPE_STRING:
             String key = decode(buffer);


### PR DESCRIPTION
Refer to: https://docs.google.com/document/d/1z6ixVD1VDlDWyPE1o6KoquU_yNJ4E79PrvFiR6RD95s/edit#heading=h.za0m8gfrsbdh

Have run bazel test StatsContextTest && bazel test StatsContextFactoryTest, all tests passed.