### PR TITLE
Add a default implementation for TimestampFactory.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,7 +15,10 @@
 java_library(
     name = "common-core",
     srcs = glob(["core/src/main/java/com/google/instrumentation/common/*.java"]),
-    deps = ["@jsr305//jar"],
+    deps = [
+        "@guava//jar",
+        "@jsr305//jar",
+    ],
 )
 
 java_library(

--- a/BUILD
+++ b/BUILD
@@ -359,6 +359,19 @@ java_test(
 )
 
 java_test(
+    name = "TimestampFactoryTest",
+    srcs = ["core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java"],
+    deps = [
+        ":common-core",
+        "@guava//jar",
+        "@guava_testlib//jar",
+        "@jsr305//jar",
+        "@junit//jar",
+        "@truth//jar",
+    ],
+)
+
+java_test(
     name = "ViewDescriptorTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java"],
     deps = [

--- a/core/src/main/java/com/google/instrumentation/common/Timestamp.java
+++ b/core/src/main/java/com/google/instrumentation/common/Timestamp.java
@@ -24,7 +24,7 @@ public final class Timestamp {
   private static final long MAX_SECONDS = 315576000000L;
   private static final int MAX_NANOS = 999999999;
   private static final long NUM_MILLIS_PER_SECOND = 1000L;
-  private static final int NUM_NANOS_PER_MILLI = 1000000;
+  private static final int NUM_NANOS_PER_MILLI = 1000 * 1000;
   private final long seconds;
   private final int nanos;
 

--- a/core/src/main/java/com/google/instrumentation/common/Timestamp.java
+++ b/core/src/main/java/com/google/instrumentation/common/Timestamp.java
@@ -16,8 +16,25 @@ package com.google.instrumentation.common;
 /**
  * A representation of an instant in time. The instant is the number of nanoseconds after the number
  * of seconds since the Unix Epoch.
+ *
+ * <p>Use {@link TimestampFactory#now} to get the current timestamp since epoch
+ * (1970-01-01T00:00:00Z).
  */
-public class Timestamp {
+public final class Timestamp {
+  private static final long MAX_SECONDS = 315576000000L;
+  private static final int MAX_NANOS = 999999999;
+  private static final long NUM_MILLIS_PER_SECOND = 1000L;
+  private static final int NUM_NANOS_PER_MILLI = 1000000;
+  private final long seconds;
+  private final int nanos;
+
+  private Timestamp(long seconds, int nanos) {
+    this.seconds = seconds;
+    this.nanos = nanos;
+  }
+
+  // TODO(bdrutu): Make create and fromMillis package-protected.
+
   /**
    * Creates a new timestamp from given seconds and nanoseconds.
    *
@@ -99,17 +116,4 @@ public class Timestamp {
   public String toString() {
     return "Timestamp<" + seconds + "," + nanos + ">";
   }
-
-  private static final long MAX_SECONDS = 315576000000L;
-  private static final int MAX_NANOS = 999999999;
-  private static final long NUM_MILLIS_PER_SECOND = 1000L;
-  private static final int NUM_NANOS_PER_MILLI = 1000000;
-  private final long seconds;
-  private final int nanos;
-
-  private Timestamp(long seconds, int nanos) {
-    this.seconds = seconds;
-    this.nanos = nanos;
-  }
-
 }

--- a/core/src/main/java/com/google/instrumentation/common/TimestampFactory.java
+++ b/core/src/main/java/com/google/instrumentation/common/TimestampFactory.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.Immutable;
 public final class TimestampFactory {
   private static final Logger logger = Logger.getLogger(TimestampFactory.class.getName());
   private static final Handler HANDLER =
-      loadTimestamFactoryHandler(Provider.getCorrectClassLoader(Handler.class));
+      loadTimestampFactoryHandler(Provider.getCorrectClassLoader(Handler.class));
 
   private TimestampFactory() {}
 
@@ -40,17 +40,20 @@ public final class TimestampFactory {
 
   // This class cannot be final because in case of java8 runtime we can have a better granularity
   // timestamp.
-  @Immutable
-  static class Handler {
-    protected Handler() {};
+  interface Handler {
+    Timestamp timeNow();
+  }
 
-    protected Timestamp timeNow() {
+  @Immutable
+  static final class DefaultHandler implements Handler {
+    @Override
+    public Timestamp timeNow() {
       return Timestamp.fromMillis(System.currentTimeMillis());
     }
   }
 
   @VisibleForTesting
-  static Handler loadTimestamFactoryHandler(ClassLoader classLoader) {
+  static Handler loadTimestampFactoryHandler(ClassLoader classLoader) {
     try {
       return Provider.createInstance(
           Class.forName(
@@ -59,6 +62,6 @@ public final class TimestampFactory {
     } catch (ClassNotFoundException e) {
       logger.log(Level.FINE, "Using default implementation for TimestampFactory$Handler.", e);
     }
-    return new Handler();
+    return new DefaultHandler();
   }
 }

--- a/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
@@ -18,18 +18,9 @@ import com.google.instrumentation.common.Timestamp;
 import javax.annotation.Nullable;
 
 /**
- * Class to create and start a {@link Span}. It also provides an implementation specific way to grab
- * the current {@link Timestamp}s for events like {@code Span} start and end or {@link NetworkEvent}
- * kernel timestamps.
+ * Factory class to create and start a {@link Span}.
  */
 abstract class SpanFactory {
-  /**
-   * Returns the current {@link Timestamp}. This is implementation specific.
-   *
-   * @return the current {@code Timestamp}.
-   */
-  abstract Timestamp timeNow();
-
   /**
    * Creates and starts a new child {@link Span} (or root if parent is {@code null}), with parent
    * being the designated {@code Span} and the given options.

--- a/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
@@ -13,8 +13,6 @@
 
 package com.google.instrumentation.trace;
 
-import com.google.instrumentation.common.Timestamp;
-
 import javax.annotation.Nullable;
 
 /**

--- a/core/src/main/java/com/google/instrumentation/trace/Tracer.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Tracer.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.instrumentation.common.NonThrowingCloseable;
 import com.google.instrumentation.common.Provider;
-import com.google.instrumentation.common.Timestamp;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/core/src/main/java/com/google/instrumentation/trace/Tracer.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Tracer.java
@@ -73,15 +73,6 @@ public final class Tracer {
   }
 
   /**
-   * Returns the current {@link Timestamp timestamp}.
-   *
-   * @return the current timestamp.
-   */
-  public Timestamp timeNow() {
-    return spanFactory.timeNow();
-  }
-
-  /**
    * Gets the current Span from the current Context.
    *
    * <p>To install a {@link Span} to the current Context use {@link #withSpan(Span)} OR use {@link
@@ -368,13 +359,6 @@ public final class Tracer {
 
   // No-op implementation of the SpanFactory
   private static final class NoopSpanFactory extends SpanFactory {
-    private static final Timestamp ZERO_TIME = Timestamp.create(0, 0);
-
-    @Override
-    public Timestamp timeNow() {
-      return ZERO_TIME;
-    }
-
     @Override
     public Span startSpan(@Nullable Span parent, String name, StartSpanOptions options) {
       return BlankSpan.INSTANCE;

--- a/core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java
+++ b/core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java
@@ -11,7 +11,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link TimestampFactory}. */
 @RunWith(JUnit4.class)
 public class TimestampFactoryTest {
-  private static final int NUM_NANOS_PER_MILLI = 1000000;
+  private static final int NUM_NANOS_PER_MILLI = 1000 * 1000;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -20,7 +20,7 @@ public class TimestampFactoryTest {
   public void millisGranularity() {
     for (int i = 0; i < 1000000; i++) {
       Timestamp now = TimestampFactory.now();
-      assertThat(now.getSeconds).isGreaterThan(0);
+      assertThat(now.getSeconds()).isGreaterThan(0L);
       assertThat(now.getNanos() % NUM_NANOS_PER_MILLI).isEqualTo(0);
     }
   }
@@ -30,7 +30,7 @@ public class TimestampFactoryTest {
     final RuntimeException toThrow = new RuntimeException("UseClassLoader");
     thrown.expect(RuntimeException.class);
     thrown.expectMessage("UseClassLoader");
-    GrpcTraceUtil.loadProtoPropagationHandler(new ClassLoader() {
+    TimestampFactory.loadTimestampFactoryHandler(new ClassLoader() {
       @Override
       public Class<?> loadClass(String name) {
         throw toThrow;
@@ -40,8 +40,8 @@ public class TimestampFactoryTest {
 
   @Test
   public void loadProtoPropagationHandler_IgnoresMissingClasses() {
-    assertThat(GrpcTraceUtil
-                   .loadProtoPropagationHandler(new ClassLoader() {
+    assertThat(TimestampFactory
+                   .loadTimestampFactoryHandler(new ClassLoader() {
                      @Override
                      public Class<?> loadClass(String name) throws ClassNotFoundException {
                        throw new ClassNotFoundException();
@@ -49,6 +49,6 @@ public class TimestampFactoryTest {
                    })
                    .getClass()
                    .getName())
-        .isEqualTo("com.google.instrumentation.common.TimestampFactory$Handler");
+        .isEqualTo("com.google.instrumentation.common.TimestampFactory$DefaultHandler");
   }
 }

--- a/core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java
+++ b/core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java
@@ -1,0 +1,54 @@
+package com.google.instrumentation.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TimestampFactory}. */
+@RunWith(JUnit4.class)
+public class TimestampFactoryTest {
+  private static final int NUM_NANOS_PER_MILLI = 1000000;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void millisGranularity() {
+    for (int i = 0; i < 1000000; i++) {
+      Timestamp now = TimestampFactory.now();
+      assertThat(now.getSeconds).isGreaterThan(0);
+      assertThat(now.getNanos() % NUM_NANOS_PER_MILLI).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void loadProtoPropagationHandler_UsesProvidedClassLoader() {
+    final RuntimeException toThrow = new RuntimeException("UseClassLoader");
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("UseClassLoader");
+    GrpcTraceUtil.loadProtoPropagationHandler(new ClassLoader() {
+      @Override
+      public Class<?> loadClass(String name) {
+        throw toThrow;
+      }
+    });
+  }
+
+  @Test
+  public void loadProtoPropagationHandler_IgnoresMissingClasses() {
+    assertThat(GrpcTraceUtil
+                   .loadProtoPropagationHandler(new ClassLoader() {
+                     @Override
+                     public Class<?> loadClass(String name) throws ClassNotFoundException {
+                       throw new ClassNotFoundException();
+                     }
+                   })
+                   .getClass()
+                   .getName())
+        .isEqualTo("com.google.instrumentation.common.TimestampFactory$Handler");
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
@@ -42,11 +42,6 @@ public class TracerTest {
   @Mock private Span span;
   @Mock private NonThrowingCloseable withSpan;
 
-  @Test
-  public void defaultTimeNow() {
-    assertThat(tracer.timeNow()).isEqualTo(Timestamp.create(0, 0));
-  }
-
   @Test(expected = NullPointerException.class)
   public void withSpan_NullSpan() {
     try (NonThrowingCloseable ws = tracer.withSpan(null)) {}


### PR DESCRIPTION
Default implementation uses System#currentTimeMillis.
Add a way to provide other implementation using java8.
Remove the Tracer#timeNow.