### PR TITLE
Remove the try-with-resources support for the Span.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/trace/ScopedSpanHandle.java
+++ b/core/src/main/java/com/google/instrumentation/trace/ScopedSpanHandle.java
@@ -18,7 +18,7 @@ import com.google.instrumentation.common.NonThrowingCloseable;
 /**
  * Defines a scope of code where the given {@link Span} is in the current context. The scope is
  * exited when the object is closed and the previous context is restored. When the scope exits the
- * given {@link Span} will be ended using {@link Span#end}.
+ * given {@code Span} will be ended using {@link Span#end}.
  *
  * <p>Supports try-with-resource idiom.
  */
@@ -27,7 +27,7 @@ final class ScopedSpanHandle implements NonThrowingCloseable {
   private final NonThrowingCloseable withSpan;
 
   /**
-   * Creates a {@link ScopedSpanHandle}
+   * Creates a {@code ScopedSpanHandle}
    *
    * @param span The span that will be installed in the current context.
    * @param contextSpanHandler The handler that is used to interact with the current context.
@@ -38,12 +38,11 @@ final class ScopedSpanHandle implements NonThrowingCloseable {
   }
 
   /**
-   * Uninstalls the {@code Span} from the current context and ends it with default options. If the
-   * span has been already ended then {@link Span#end()} is a no-op.
+   * Uninstalls the {@code Span} from the current context and ends it by calling {@link Span#end()}.
    */
   @Override
   public void close() {
     withSpan.close();
-    span.end(EndSpanOptions.DEFAULT);
+    span.end();
   }
 }

--- a/core/src/main/java/com/google/instrumentation/trace/Span.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Span.java
@@ -15,8 +15,6 @@ package com.google.instrumentation.trace;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.instrumentation.common.NonThrowingCloseable;
-
 import java.util.EnumSet;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -27,10 +25,9 @@ import javax.annotation.Nullable;
  *
  * <p>Spans are created by the {@link SpanBuilder#startSpan} method.
  *
- * <p>{@code Span} implements NonThrowingCloseable, to support try-with-resource idiom. See {@link
- * Span#close}.
+ * <p>{@code Span} <b>must</b> be ended by calling {@link #end()} or {@link #end(EndSpanOptions)}
  */
-public abstract class Span implements NonThrowingCloseable {
+public abstract class Span {
   // Contains the identifiers associated with this Span.
   private final SpanContext context;
 
@@ -146,7 +143,6 @@ public abstract class Span implements NonThrowingCloseable {
   /**
    * Ends the current {@code Span} by calling {@link #end}.
    */
-  @Override
   public final void close() {
     end(EndSpanOptions.DEFAULT);
   }

--- a/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
@@ -94,9 +94,10 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(false), same(SPAN_NAME), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span rootSpan = spanBuilder.becomeRoot().startSpan()) {
-      assertThat(rootSpan).isEqualTo(span);
-    }
+    Span rootSpan = spanBuilder.becomeRoot().startSpan();
+    assertThat(rootSpan).isEqualTo(span);
+    rootSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -107,9 +108,10 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(false), same(SPAN_NAME), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span rootSpan = spanBuilder.startSpan()) {
-      assertThat(rootSpan).isEqualTo(span);
-    }
+    Span rootSpan = spanBuilder.startSpan();
+    assertThat(rootSpan).isEqualTo(span);
+    rootSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -121,14 +123,15 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(false), same(SPAN_NAME), eq(startSpanOptions)))
         .thenReturn(span);
-    try (Span rootSpan =
+    Span rootSpan =
         spanBuilder
             .becomeRoot()
             .setSampler(Samplers.neverSample())
             .setParentLinks(parentList)
-            .startSpan()) {
-      assertThat(rootSpan).isEqualTo(span);
-    }
+            .startSpan();
+    assertThat(rootSpan).isEqualTo(span);
+    rootSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -136,9 +139,10 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             same(spanContext), eq(false), same(SPAN_NAME), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span childSpan = spanBuilder.startSpan()) {
-      assertThat(childSpan).isEqualTo(span);
-    }
+    Span childSpan = spanBuilder.startSpan();
+    assertThat(childSpan).isEqualTo(span);
+    childSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -148,10 +152,11 @@ public class SpanBuilderTest {
     startSpanOptions.setRecordEvents(true);
     when(spanFactory.startSpan(same(spanContext), eq(false), same(SPAN_NAME), eq(startSpanOptions)))
         .thenReturn(span);
-    try (Span childSpan =
-        spanBuilder.setSampler(Samplers.neverSample()).setRecordEvents(true).startSpan()) {
-      assertThat(childSpan).isEqualTo(span);
-    }
+    Span childSpan =
+        spanBuilder.setSampler(Samplers.neverSample()).setRecordEvents(true).startSpan();
+    assertThat(childSpan).isEqualTo(span);
+    childSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -162,9 +167,10 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             same(spanContext), eq(true), same(SPAN_NAME), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span remoteChildSpan = spanBuilder.startSpan()) {
-      assertThat(remoteChildSpan).isEqualTo(span);
-    }
+    Span remoteChildSpan = spanBuilder.startSpan();
+    assertThat(remoteChildSpan).isEqualTo(span);
+    remoteChildSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
@@ -175,8 +181,9 @@ public class SpanBuilderTest {
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(true), same(SPAN_NAME), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span remoteChildSpan = spanBuilder.startSpan()) {
-      assertThat(remoteChildSpan).isEqualTo(span);
-    }
+    Span remoteChildSpan = spanBuilder.startSpan();
+    assertThat(remoteChildSpan).isEqualTo(span);
+    remoteChildSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 }

--- a/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
@@ -68,13 +68,6 @@ public class SpanTest {
     verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
-  @Test
-  public void closeCallsEndWithDefaultOptions() {
-    Span span = Mockito.spy(new NoopSpan(spanContext, spanOptions));
-    span.close();
-    verify(span).end(same(EndSpanOptions.DEFAULT));
-  }
-
   // No-op implementation of the Span for testing only.
   private static class NoopSpan extends Span {
     private NoopSpan(SpanContext context, EnumSet<Span.Options> options) {

--- a/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
@@ -200,10 +200,10 @@ public class TracerTest {
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(false), eq("MySpanName"), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span rootSpan =
-        mockTracer.spanBuilder(BlankSpan.INSTANCE, "MySpanName").becomeRoot().startSpan()) {
-      assertThat(rootSpan).isEqualTo(span);
-    }
+    Span rootSpan =
+        mockTracer.spanBuilder(BlankSpan.INSTANCE, "MySpanName").becomeRoot().startSpan();
+    assertThat(rootSpan).isEqualTo(span);
+    rootSpan.end();
     verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
@@ -216,9 +216,9 @@ public class TracerTest {
             eq("MySpanName"),
             eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span childSpan = mockTracer.spanBuilder(BlankSpan.INSTANCE, "MySpanName").startSpan()) {
-      assertThat(childSpan).isEqualTo(span);
-    }
+    Span childSpan = mockTracer.spanBuilder(BlankSpan.INSTANCE, "MySpanName").startSpan();
+    assertThat(childSpan).isEqualTo(span);
+    childSpan.end();
     verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
@@ -234,10 +234,11 @@ public class TracerTest {
     when(spanFactory.startSpan(
             same(spanContext), eq(true), eq("MySpanName"), eq(new StartSpanOptions())))
         .thenReturn(span);
-    try (Span remoteChildSpan =
-        mockTracer.spanBuilderWithRemoteParent(spanContext, "MySpanName").startSpan()) {
-      assertThat(remoteChildSpan).isEqualTo(span);
-    }
+    Span remoteChildSpan =
+        mockTracer.spanBuilderWithRemoteParent(spanContext, "MySpanName").startSpan();
+    assertThat(remoteChildSpan).isEqualTo(span);
+    remoteChildSpan.end();
+    verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   private Tracer newTracerWithMocks() {

--- a/examples/src/main/java/com/google/instrumentation/trace/BasicTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/trace/BasicTracing.java
@@ -19,9 +19,9 @@ public final class BasicTracing {
   private static final Tracer tracer = Tracer.getTracer();
 
   private static void doWork() {
-    try (Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan()) {
-      span.addAnnotation("This annotation is added directly to the span.");
-    }
+    Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+    span.addAnnotation("This annotation is added directly to the span.");
+    span.end();
   }
 
   public static void main(String[] args) {

--- a/examples/src/main/java/com/google/instrumentation/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/trace/MultiSpansTracing.java
@@ -19,13 +19,13 @@ public final class MultiSpansTracing {
   private static final Tracer tracer = Tracer.getTracer();
 
   private static void doWork() {
-    try (Span rootSpan = tracer.spanBuilder(null, "MyRootSpan").startSpan()) {
-      rootSpan.addAnnotation("Annotation to the root Span before child is created.");
-      try (Span childSpan = tracer.spanBuilder(rootSpan, "MyChildSpan").startSpan()) {
-        childSpan.addAnnotation("Annotation to the child Span");
-      }
-      rootSpan.addAnnotation("Annotation to the root Span after child is ended.");
-    }
+    Span rootSpan = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+    rootSpan.addAnnotation("Annotation to the root Span before child is created.");
+    Span childSpan = tracer.spanBuilder(rootSpan, "MyChildSpan").startSpan();
+    childSpan.addAnnotation("Annotation to the child Span");
+    childSpan.end();
+    rootSpan.addAnnotation("Annotation to the root Span after child is ended.");
+    rootSpan.end();
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
This is important because we want to discourage the usage of the Span and encourage the usage of ScopedSpan.

Now SpanBuild#startSpan is only for manual propagation and there is no confusion that the try-with-resources objects will interact with the Context and Span does not.