### PR TITLE
Update travis to run guava 21 only for java8 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ matrix:
     env: BUILD=MVN GUAVA_VERSION=19.0
 
   - jdk: oraclejdk7
-    env: BUILD=MVN GUAVA_VERSION=21.0
+    env: BUILD=MVN GUAVA_VERSION=20.0
 
   - jdk: oraclejdk8
     env: BUILD=MVN GUAVA_VERSION=19.0
 
   - jdk: oraclejdk8
     env: BUILD=MVN GUAVA_VERSION=20.0
+
+  - jdk: oraclejdk8
+    env: BUILD=MVN GUAVA_VERSION=21.0
 
   - jdk: oraclejdk8
     env: BUILD=BAZEL


### PR DESCRIPTION
Guava 21 works only on java8. See https://github.com/google/guava/wiki/Release21.