### PR TITLE
Remove redundant fields in pom.xml files.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,9 +5,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.census</groupId>
   <artifactId>census-core</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
 
   <name>Census Java Core</name>
   <url>https://github.com/google/instrumentation-java</url>

--- a/core_context_impl/pom.xml
+++ b/core_context_impl/pom.xml
@@ -5,9 +5,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.census</groupId>
   <artifactId>census-core_context_impl</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
 
   <name>Census Java Core Context Impl</name>
   <url>https://github.com/google/instrumentation-java</url>

--- a/core_impl/pom.xml
+++ b/core_impl/pom.xml
@@ -5,9 +5,7 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.census</groupId>
   <artifactId>census-core_impl</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
 
   <name>Census Java Core Impl</name>
   <url>https://github.com/google/instrumentation-java</url>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -5,7 +5,6 @@
 
   <groupId>com.google.io</groupId>
   <artifactId>shared</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
 
   <parent>
     <groupId>com.google.census</groupId>


### PR DESCRIPTION
These fields were the same as the parent pom.xml.