### PR TITLE
Cleanup pom.xml in our implementation packages.

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -16,11 +16,15 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.census</groupId>
       <artifactId>census-core</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -16,10 +16,6 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.census</groupId>
@@ -86,10 +82,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/core_impl/pom.xml
+++ b/core_impl/pom.xml
@@ -16,10 +16,6 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.census</groupId>
@@ -56,10 +52,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/core_impl/pom.xml
+++ b/core_impl/pom.xml
@@ -16,21 +16,25 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.census</groupId>
       <artifactId>census-core</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.census</groupId>
       <artifactId>census-proto</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.io</groupId>
       <artifactId>shared</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,14 @@
       <modules>
         <module>benchmarks</module>
       </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -12,6 +12,10 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -12,10 +12,6 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <properties>
-    <maven.javadoc.skip>true</maven.javadoc.skip>
-  </properties>
-
   <build>
     <plugins>
       <plugin>
@@ -29,10 +25,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Use the current version for dependencies between different internal packages.
Avoid generating javadocs for implementation packages.