### PR TITLE
Add sample code for reading proto binaries on descriptor constants during run time.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,8 +30,12 @@ java_library(
     name = "stats-core",
     srcs = glob(["core/src/main/java/com/google/instrumentation/stats/*.java"]),
     deps = [
-        ":common-core",
+        "@guava//jar",
         "@jsr305//jar",
+        "@protobuf//jar",
+        ":common-core",
+        "//proto:census-proto-java",
+        "//proto:view_descriptor_constants-proto-java",
     ],
 )
 
@@ -39,9 +43,9 @@ java_library(
     name = "trace-core",
     srcs = glob(["core/src/main/java/com/google/instrumentation/trace/*.java"]),
     deps = [
-        ":common-core",
         "@guava//jar",
         "@jsr305//jar",
+        ":common-core",
     ],
 )
 
@@ -49,10 +53,10 @@ java_library(
     name = "trace-core_context_impl",
     srcs = glob(["core_context_impl/src/main/java/com/google/instrumentation/trace/*.java"]),
     deps = [
-        ":common-core",
-        ":trace-core",
         "@grpc_context//jar",
         "@jsr305//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -60,11 +64,11 @@ java_library(
     name = "stats-core_impl",
     srcs = glob(["core_impl/src/main/java/com/google/instrumentation/stats/*.java"]),
     deps = [
+        "@jsr305//jar",
+        "@protobuf//jar",
         ":shared",
         ":stats-core",
         "//proto:stats_context-proto-java",
-        "@jsr305//jar",
-        "@protobuf//jar",
     ],
 )
 
@@ -73,11 +77,11 @@ java_binary(
     srcs = ["examples/src/main/java/com/google/instrumentation/stats/StatsRunner.java"],
     main_class = "com.google.instrumentation.stats.StatsRunner",
     deps = [
-        ":stats-core",
-        ":stats-core_impl",
         "@grpc_context//jar",
         "@guava//jar",
         "@jsr305//jar",
+        ":stats-core",
+        ":stats-core_impl",
     ],
 )
 
@@ -145,12 +149,12 @@ java_test(
         "core/src/test/java/com/google/instrumentation/stats/DistributionAggregationDescriptorTest.java",
     ],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -160,12 +164,12 @@ java_test(
         "core/src/test/java/com/google/instrumentation/stats/DistributionAggregationTest.java",
     ],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -175,13 +179,13 @@ java_test(
         "core/src/test/java/com/google/instrumentation/stats/IntervalAggregationDescriptorTest.java",
     ],
     deps = [
-        ":common-core",
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":stats-core",
     ],
 )
 
@@ -191,13 +195,13 @@ java_test(
         "core/src/test/java/com/google/instrumentation/stats/IntervalAggregationTest.java",
     ],
     deps = [
-        ":common-core",
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":stats-core",
     ],
 )
 
@@ -205,11 +209,11 @@ java_test(
     name = "MeasurementMapTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/MeasurementMapTest.java"],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -217,12 +221,12 @@ java_test(
     name = "MeasurementDescriptorTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java"],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -230,12 +234,29 @@ java_test(
     name = "RpcConstantsTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/RpcConstantsTest.java"],
     deps = [
-        ":stats-core",
-        ":stats-core_impl",
         "@guava//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
+        ":stats-core_impl",
+    ],
+)
+
+java_test(
+    name = "RpcConstantsFromProtoBinaryTest",
+    srcs = [
+        "core/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoBinaryTest.java",
+    ],
+    deps = [
+        "@guava//jar",
+        "@jsr305//jar",
+        "@junit//jar",
+        "@protobuf//jar",
+        "@truth//jar",
+        ":stats-core",
+        ":stats-core_impl",
+        "//proto:census-proto-java",
     ],
 )
 
@@ -243,13 +264,13 @@ java_test(
     name = "StatsContextTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/StatsContextTest.java"],
     deps = [
-        ":stats-core",
-        ":stats-core_impl",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
+        ":stats-core_impl",
     ],
 )
 
@@ -257,13 +278,13 @@ java_test(
     name = "StatsContextFactoryTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java"],
     deps = [
-        ":shared",
-        ":stats-core",
-        ":stats-core_impl",
         "@guava//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":shared",
+        ":stats-core",
+        ":stats-core_impl",
     ],
 )
 
@@ -271,13 +292,13 @@ java_test(
     name = "StringUtilTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/StringUtilTest.java"],
     deps = [
-        ":stats-core",
-        ":stats-core_impl",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
+        ":stats-core_impl",
     ],
 )
 
@@ -285,12 +306,12 @@ java_test(
     name = "TagKeyTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/TagKeyTest.java"],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -298,12 +319,12 @@ java_test(
     name = "TagTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/TagTest.java"],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -311,12 +332,12 @@ java_test(
     name = "TagValueTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/TagValueTest.java"],
     deps = [
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":stats-core",
     ],
 )
 
@@ -324,12 +345,12 @@ java_test(
     name = "DurationTest",
     srcs = ["core/src/test/java/com/google/instrumentation/common/DurationTest.java"],
     deps = [
-        ":common-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
     ],
 )
 
@@ -337,12 +358,12 @@ java_test(
     name = "ProviderTest",
     srcs = ["core/src/test/java/com/google/instrumentation/common/ProviderTest.java"],
     deps = [
-        ":common-core",
-        ":stats-core",
         "@guava//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":stats-core",
     ],
 )
 
@@ -350,12 +371,12 @@ java_test(
     name = "TimestampTest",
     srcs = ["core/src/test/java/com/google/instrumentation/common/TimestampTest.java"],
     deps = [
-        ":common-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
     ],
 )
 
@@ -363,12 +384,12 @@ java_test(
     name = "TimestampFactoryTest",
     srcs = ["core/src/test/java/com/google/instrumentation/common/TimestampFactoryTest.java"],
     deps = [
-        ":common-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
     ],
 )
 
@@ -376,13 +397,13 @@ java_test(
     name = "ViewDescriptorTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java"],
     deps = [
-        ":common-core",
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":stats-core",
     ],
 )
 
@@ -390,13 +411,13 @@ java_test(
     name = "ViewTest",
     srcs = ["core/src/test/java/com/google/instrumentation/stats/ViewTest.java"],
     deps = [
-        ":common-core",
-        ":stats-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":stats-core",
     ],
 )
 
@@ -404,13 +425,13 @@ java_test(
     name = "BlankSpanTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/BlankSpanTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -418,13 +439,13 @@ java_test(
     name = "EndSpanOptionsTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/EndSpanOptionsTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -432,12 +453,12 @@ java_test(
     name = "HttpPropagationUtilTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/HttpPropagationUtilTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -445,12 +466,12 @@ java_test(
     name = "LabelValueTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/LabelValueTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -458,12 +479,12 @@ java_test(
     name = "LabelsTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/LabelsTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -471,13 +492,13 @@ java_test(
     name = "NetworkEventTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/NetworkEventTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -485,12 +506,12 @@ java_test(
     name = "SamplersTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/SamplersTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -498,14 +519,14 @@ java_test(
     name = "ScopedSpanHandleTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/ScopedSpanHandleTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@mockito//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -513,14 +534,14 @@ java_test(
     name = "SpanBuilderTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@mockito//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -528,12 +549,12 @@ java_test(
     name = "SpanContextTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/SpanContextTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -541,12 +562,12 @@ java_test(
     name = "SpanIdTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/SpanIdTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -554,14 +575,14 @@ java_test(
     name = "SpanTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/SpanTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@mockito//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -569,13 +590,13 @@ java_test(
     name = "StartSpanOptionsTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/StartSpanOptionsTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -583,12 +604,12 @@ java_test(
     name = "StatusTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/StatusTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -596,12 +617,12 @@ java_test(
     name = "TraceIdTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/TraceIdTest.java"],
     deps = [
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":trace-core",
     ],
 )
 
@@ -609,13 +630,13 @@ java_test(
     name = "TraceOptionsTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/TraceOptionsTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -623,14 +644,14 @@ java_test(
     name = "TracerTest",
     srcs = ["core/src/test/java/com/google/instrumentation/trace/TracerTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
         "@guava//jar",
         "@guava_testlib//jar",
         "@jsr305//jar",
         "@junit//jar",
         "@mockito//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
     ],
 )
 
@@ -638,9 +659,6 @@ java_test(
     name = "ContextSpanHandlerImplTest",
     srcs = ["core_context_impl/src/test/java/com/google/instrumentation/trace/ContextSpanHandlerImplTest.java"],
     deps = [
-        ":common-core",
-        ":trace-core",
-        ":trace-core_context_impl",
         "@grpc_context//jar",
         "@guava//jar",
         "@guava_testlib//jar",
@@ -648,5 +666,8 @@ java_test(
         "@junit//jar",
         "@mockito//jar",
         "@truth//jar",
+        ":common-core",
+        ":trace-core",
+        ":trace-core_context_impl",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,29 +70,9 @@ maven_jar(
     artifact = "junit:junit:4.11",
 )
 
-<<<<<<< HEAD
-# proto_library rules implicitly depend on @com_google_protobuf//:protoc,
-# which is the proto-compiler.
-# This statement defines the @com_google_protobuf repo.
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "ff771a662fb6bd4d3cc209bcccedef3e93980a49f71df1e987f6afa3bcdcba3a",
-    strip_prefix = "protobuf-b4b0e304be5a68de3d0ee1af9b286f958750f5e4",
-    urls = ["https://github.com/google/protobuf/archive/b4b0e304be5a68de3d0ee1af9b286f958750f5e4.zip"],
-)
-
-# java_proto_library rules implicitly depend on @com_google_protobuf_java//:java_toolchain,
-# which is the Java proto runtime (base classes and common utilities).
-http_archive(
-    name = "com_google_protobuf_java",
-    sha256 = "ff771a662fb6bd4d3cc209bcccedef3e93980a49f71df1e987f6afa3bcdcba3a",
-    strip_prefix = "protobuf-b4b0e304be5a68de3d0ee1af9b286f958750f5e4",
-    urls = ["https://github.com/google/protobuf/archive/b4b0e304be5a68de3d0ee1af9b286f958750f5e4.zip"],
-=======
 maven_jar(
     name = "jmh",
     artifact = "org.openjdk.jmh:jmh-core:1.18",
->>>>>>> 0ed88a869a1d414dd067796c7b7a360970e247f8
 )
 
 git_repository(

--- a/core/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProtoBinary.java
+++ b/core/src/main/java/com/google/instrumentation/stats/RpcConstantsFromProtoBinary.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+import com.google.common.io.Files;
+import com.google.instrumentation.stats.proto.CensusProto;
+import com.google.instrumentation.stats.proto.ViewDescriptorConstantsProto;
+import com.google.instrumentation.stats.proto.ViewDescriptorConstantsProto.ViewDescriptorConstants;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Constants for collecting rpc stats.
+ */
+public class RpcConstantsFromProtoBinary {
+  private static ViewDescriptorConstantsProto.ViewDescriptorConstants viewDescriptorConstants;
+
+  // The proto binary will be read during run-time. File location of the binary could be different
+  // depending on how we finally decide to place the proto binary files.
+  private static final String rpcConstantsProtoBinaryFilePath =
+      "REPLACE THIS WITH THE PATH TO RPC CONSTANTS PROTO BINARY FILE.";
+
+  static {
+    final File rpcConstantsProtoBinary = new File(rpcConstantsProtoBinaryFilePath);
+    try {
+      byte[] rpcConstantsProtoBinaryBytes = Files.toByteArray(rpcConstantsProtoBinary);
+      viewDescriptorConstants = ViewDescriptorConstants.parseFrom(rpcConstantsProtoBinaryBytes);
+    } catch (IOException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public static final List<CensusProto.MeasurementDescriptor> getMeasurementDescriptorList() {
+    return viewDescriptorConstants.getMeasurementDescriptorList();
+  }
+
+  public static final List<CensusProto.ViewDescriptor> getViewDescriptorList() {
+    return viewDescriptorConstants.getViewDescriptorList();
+  }
+
+  private RpcConstantsFromProtoBinary() {
+    throw new AssertionError();
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoBinaryTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/RpcConstantsFromProtoBinaryTest.java
@@ -1,0 +1,26 @@
+package com.google.instrumentation.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.instrumentation.stats.proto.CensusProto;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link RpcConstants}
+ */
+@RunWith(JUnit4.class)
+public class RpcConstantsFromProtoBinaryTest {
+  private List<CensusProto.MeasurementDescriptor> measurementDescriptorList =
+      RpcConstantsFromProtoBinary.getMeasurementDescriptorList();
+  private List<CensusProto.ViewDescriptor> viewDescriptorList =
+      RpcConstantsFromProtoBinary.getViewDescriptorList();
+
+  @Test
+  public void testConstants() {
+    assertThat(measurementDescriptorList).isNotEmpty();
+    assertThat(viewDescriptorList).isNotEmpty();
+  }
+}


### PR DESCRIPTION
This change demonstrates how to read and parse binary text-proto files and retrieve RPC constants during run time. This should not be merged until we have finally decided where to place the proto binary file (rpc_constants.pb).