### PR TITLE
Remove all occurrences of "Census" from documentation.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,7 +10,7 @@
 # limitations under the License.
 
 # Description:
-#   Open source Census for cloud services.
+#   Open source Instrumentation for cloud services.
 
 java_library(
     name = "common-core",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We commonly need to know what platform you are on:
 
 # How to contribute
 
-We definitely welcome patches and contributions to Census! Here are some
+We definitely welcome patches and contributions to Instrumentation! Here are some
 guideline and information about how to do so.
 
 ## Before getting started
@@ -30,4 +30,4 @@ Style, and set the Scheme to `GoogleStyle`.
 
 Make sure that `bazel build :all` completes successfully without any new warnings.
 Then create a Pull Request with your changes. When the changes are accepted, they
-will be merged or cherry-picked by a Census core developer.
+will be merged or cherry-picked by an Instrumentation core developer.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-Census - A stats collection framework
+Instrumentation - A stats collection framework
 ======================================================
 [![Build Status](https://travis-ci.org/google/instrumentation-java.svg?branch=master)](https://travis-ci.org/google/instrumentation-java)
 
-Census provides a framework to define and collect stats against metrics and to
+Instrumentation provides a framework to define and collect stats against metrics and to
 break those stats down across user-defined dimensions.

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>census-benchmarks</artifactId>
 
-  <name>Census Java Benchmarks</name>
+  <name>Instrumentation Java Benchmarks</name>
   <url>https://github.com/google/instrumentation-java</url>
 
   <parent>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>census-core</artifactId>
 
-  <name>Census Java Core</name>
+  <name>Instrumentation Java Core</name>
   <url>https://github.com/google/instrumentation-java</url>
 
   <parent>

--- a/core/src/main/java/com/google/instrumentation/stats/RpcConstants.java
+++ b/core/src/main/java/com/google/instrumentation/stats/RpcConstants.java
@@ -37,7 +37,7 @@ public final class RpcConstants {
   private static final List<BasicUnit> scalar = Arrays.asList(BasicUnit.SCALAR);
   private static final List<BasicUnit> seconds = Arrays.asList(BasicUnit.SECONDS);
 
-  // Census defined rpc client {@link MeasurementDescriptor}s.
+  // RPC client {@link MeasurementDescriptor}s.
   public static final MeasurementDescriptor RPC_CLIENT_ERROR_COUNT =
       MeasurementDescriptor.create(
           "/rpc/client/error_count",
@@ -74,7 +74,7 @@ public final class RpcConstants {
           "Uncompressed Response bytes",
           MeasurementUnit.create(0, bytes));
 
-  // Census defined rpc server {@link MeasurementDescriptor}s.
+  // RPC server {@link MeasurementDescriptor}s.
   public static final MeasurementDescriptor RPC_SERVER_ERROR_COUNT =
       MeasurementDescriptor.create(
           "/rpc/server/error_count",
@@ -132,7 +132,7 @@ public final class RpcConstants {
           40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0,
           800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0));
 
-  // Census defined rpc client {@link ViewDescriptor}s.
+  // Rpc client {@link ViewDescriptor}s.
   public static final DistributionViewDescriptor RPC_CLIENT_ERROR_COUNT_VIEW =
       DistributionViewDescriptor.create(
           "rpc client error_count",
@@ -184,7 +184,7 @@ public final class RpcConstants {
           Arrays.asList(RPC_CLIENT_METHOD));
 
 
-  // Census defined rpc server {@link ViewDescriptor}s.
+  // Rpc server {@link ViewDescriptor}s.
   public static final DistributionViewDescriptor RPC_SERVER_ERROR_COUNT_VIEW =
       DistributionViewDescriptor.create(
           "rpc server error_count",
@@ -239,7 +239,7 @@ public final class RpcConstants {
   static final Duration MINUTE = Duration.create(60, 0);
   static final Duration HOUR = Duration.create(60 * 60, 0);
 
-  // Census defined rpc client {@link IntervalViewDescriptor}s.
+  // RPC client {@link IntervalViewDescriptor}s.
   public static final IntervalViewDescriptor RPC_CLIENT_ROUNDTRIP_LATENCY_INTERVAL_VIEW =
       IntervalViewDescriptor.create(
           "rpc client roundtrip_latency",
@@ -296,7 +296,7 @@ public final class RpcConstants {
           IntervalAggregationDescriptor.create(Arrays.asList(MINUTE, HOUR)),
           Arrays.asList(RPC_CLIENT_METHOD));
 
-  // Census defined rpc server {@link IntervalViewDescriptor}s.
+  // RPC server {@link IntervalViewDescriptor}s.
   public static final IntervalViewDescriptor RPC_SERVER_SERVER_LATENCY_INTERVAL_VIEW =
       IntervalViewDescriptor.create(
           "rpc server server_latency",

--- a/core/src/main/java/com/google/instrumentation/stats/TagKey.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagKey.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 /**
- * Census Tag keys.
+ * Tag keys.
  *
  * <p>TagKey's are {@link String}s with enforced restrictions.
  */

--- a/core/src/main/java/com/google/instrumentation/stats/TagValue.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagValue.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 /**
- * Census Tag values.
+ * Tag values.
  *
  * <p>TagValue's are {@link String}s with enforced restrictions.
  */

--- a/core_impl/pom.xml
+++ b/core_impl/pom.xml
@@ -7,7 +7,7 @@
 
   <artifactId>census-core_impl</artifactId>
 
-  <name>Census Java Core Impl</name>
+  <name>Instrumentation Java Core Impl</name>
   <url>https://github.com/google/instrumentation-java</url>
 
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>census-parent</artifactId>
   <version>0.1.0-SNAPSHOT</version>
 
-  <name>Census Java</name>
+  <name>Instrumentation Java</name>
 
   <description>
     Instrumentation provides a library that includes functionality for tracing,


### PR DESCRIPTION
Now we only use "Census" for existing Protocol Buffer messages, Maven group IDs,
and Maven artifact IDs.