### PR TITLE
Change project name to be instrumentation-java.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
         ./gradlew clean assemble --stacktrace ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")
-            ./gradlew check :instrumentation-all:jacocoTestReport ;;
+            ./gradlew check :instrumentation-java-all:jacocoTestReport ;;
           "oraclejdk7")
             ./gradlew check ;;
           "openjdk6")
@@ -66,7 +66,7 @@ script:
 
 after_success:
   - if \[ "$BUILD" = "GRADLE" \] &&  \[ "$TRAVIS_JDK_VERSION" == "oraclejdk8" \]; then
-    ./gradlew :instrumentation-all:coveralls --stacktrace ;
+    ./gradlew :instrumentation-java-all:coveralls --stacktrace ;
     bash <(curl -s https://codecov.io/bash) ;
     fi
 

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 }
 
 def subprojects = [
-  project(':instrumentation-core'),
-  project(':instrumentation-core-impl'),
+  project(':instrumentation-java-core'),
+  project(':instrumentation-java-core-impl'),
 ]
 
 for (subproject in rootProject.subprojects) {

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,7 @@
-Instrumentation Benchmarks
-==============================================
+# Instrumentation Benchmarks
 
 ## To run the benchmark type
 
 ```
-$ ./gradlew :instrumentation-benchmarks:jmh
+$ ./gradlew :instrumentation-java-benchmarks:jmh
 ```

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -23,7 +23,7 @@ jmh {
 }
 
 dependencies {
-    compile project(':instrumentation-core')
+    compile project(':instrumentation-java-core')
 }
 
 compileJmhJava {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
             libraries.grpc_context,
             libraries.guava
 
-    testCompile project(':instrumentation-core-impl'),
+    testCompile project(':instrumentation-java-core-impl'),
             libraries.grpc_context
 
     signature "org.codehaus.mojo.signature:java16:+@signature"

--- a/core_impl/build.gradle
+++ b/core_impl/build.gradle
@@ -1,7 +1,7 @@
 description = 'Instrumentation Core Impl'
 
 dependencies {
-    compile project(':instrumentation-core'),
+    compile project(':instrumentation-java-core'),
             project(':proto'),
             libraries.disruptor,
             libraries.guava

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -6,8 +6,8 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    compile project(':instrumentation-core'),
-            project(':instrumentation-core-impl'),
+    compile project(':instrumentation-java-core'),
+            project(':instrumentation-java-core-impl'),
             libraries.grpc_context
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,15 @@
-rootProject.name = "instrumentation"
-include ":instrumentation-all"
-include ":instrumentation-benchmarks"
-include ":instrumentation-core"
-include ":instrumentation-core-impl"
+rootProject.name = "instrumentation-java"
+include ":instrumentation-java-all"
+include ":instrumentation-java-benchmarks"
+include ":instrumentation-java-core"
+include ":instrumentation-java-core-impl"
 include ":proto"
 include ":shared"
 
-project(':instrumentation-all').projectDir = "$rootDir/all" as File
-project(':instrumentation-benchmarks').projectDir = "$rootDir/benchmarks" as File
-project(':instrumentation-core').projectDir = "$rootDir/core" as File
-project(':instrumentation-core-impl').projectDir = "$rootDir/core_impl" as File
+project(':instrumentation-java-all').projectDir = "$rootDir/all" as File
+project(':instrumentation-java-benchmarks').projectDir = "$rootDir/benchmarks" as File
+project(':instrumentation-java-core').projectDir = "$rootDir/core" as File
+project(':instrumentation-java-core-impl').projectDir = "$rootDir/core_impl" as File
 project(':proto').projectDir = "$rootDir/proto" as File
 project(':shared').projectDir = "$rootDir/shared" as File
 


### PR DESCRIPTION
Helps IDEs to have the same name as the main directory.