### PR TITLE
Add Annotation and Link as classes in the trace API.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,13 @@ subprojects {
         reportLevel = 'low'		        // low = sensitive to even minor mistakes
         omitVisitors = []		        // bugs that we want to ignore
     }
+    // Generate html report for findbugs.
+    findbugsMain {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+    }
     // TODO(bdrutu): Enable this when the proto will generate the builds in build not in
     // build_gradle.
     findbugsMain.onlyIf { !name.contains("proto") }

--- a/core/src/main/java/com/google/instrumentation/trace/Annotation.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Annotation.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import javax.annotation.concurrent.Immutable;
+
+/** A text annotation with a set of attributes. */
+@Immutable
+public final class Annotation {
+  private final String description;
+  private final Attributes attributes;
+
+  /**
+   * Returns a new {@code Annotation} with the given description.
+   *
+   * @param description the text description of the {@code Annotation}.
+   * @return a new {@code Annotation} with the given description.
+   * @throws NullPointerException if {@code description} is {@code null}.
+   */
+  public static Annotation fromDescription(String description) {
+    return new Annotation(description, Attributes.EMPTY);
+  }
+
+  /**
+   * Returns a new {@code Annotation} with the given description and set of attributes.
+   *
+   * @param description the text description of the {@code Annotation}.
+   * @param attributes the attributes of the {@code Annotation}.
+   * @return a new {@code Annotation} with the given description and set of attributes.
+   * @throws NullPointerException if {@code description} or {@code attributes} are {@code null}.
+   */
+  public static Annotation fromDescriptionAndAttributes(String description, Attributes attributes) {
+    return new Annotation(description, attributes);
+  }
+
+  /**
+   * Return the description of the {@code Annotation}.
+   *
+   * @return the description of the {@code Annotation}.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Return the attributes of the {@code Annotation}.
+   *
+   * @return the attributes of the {@code Annotation}.
+   */
+  public Attributes getAttributes() {
+    return attributes;
+  }
+
+  private Annotation(String description, Attributes attributes) {
+    this.description = checkNotNull(description, "description");
+    this.attributes = checkNotNull(attributes, "attributes");
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/trace/Attributes.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Attributes.java
@@ -28,6 +28,10 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class Attributes {
+  /** Empty {@code Attributes} value. */
+  public static final Attributes EMPTY =
+      new Attributes(Collections.<String, AttributeValue>emptyMap());
+
   // This object is an immutable Map.
   private final Map<String, AttributeValue> attributes;
 
@@ -43,6 +47,17 @@ public final class Attributes {
    */
   public static Builder builder() {
     return new Builder();
+  }
+
+  /**
+   * Returns a new {@code Attributes} with the given values.
+   *
+   * @param attributes a map representation of the {@code Attributes}.
+   * @return a new {@code Attributes} with the given values.
+   * @throws NullPointerException if {@code attribute} is {@code null}.
+   */
+  public static Attributes fromMap(Map<String, AttributeValue> attributes) {
+    return new Attributes((checkNotNull(attributes, "attributes")));
   }
 
   /**

--- a/core/src/main/java/com/google/instrumentation/trace/BlankSpan.java
+++ b/core/src/main/java/com/google/instrumentation/trace/BlankSpan.java
@@ -42,13 +42,17 @@ public final class BlankSpan extends Span {
   @Override
   public void addAnnotation(String description, Attributes attributes) {}
 
+  /** No-op implementation of the {@link Span#addAnnotation(Annotation)} method. */
+  @Override
+  public void addAnnotation(Annotation annotation) {}
+
   /** No-op implementation of the {@link Span#addNetworkEvent(NetworkEvent)} method. */
   @Override
   public void addNetworkEvent(NetworkEvent networkEvent) {}
 
-  /** No-op implementation of the {@link Span#addChildLink(Span)} method. */
+  /** No-op implementation of the {@link Span#addLink(Link)} method. */
   @Override
-  public void addChildLink(Span childLink) {}
+  public void addLink(Link link) {}
 
   /** No-op implementation of the {@link Span#end(EndSpanOptions)} method. */
   @Override

--- a/core/src/main/java/com/google/instrumentation/trace/Link.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Link.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A link to a {@link Span} from a different trace.
+ *
+ * <p>It requires a {@link Type} which describes the relationship with the linked {@code Span}
+ * and the identifiers of the linked {@code Span}.
+ *
+ * <p>Used (for example) in batching operations, where a single batch handler processes multiple
+ * requests from different traces.
+ */
+@Immutable
+public final class Link {
+  /**
+   * The relationship with the linked {@code Span} relative to the current {@code Span}.
+   */
+  public enum Type {
+    /**
+     * When the linked {@code Span} is a child of the current {@code Span}.
+     */
+    CHILD,
+    /**
+     * When the linked {@code Span} is a parent of the current {@code Span}.
+     */
+    PARENT
+  }
+
+  private final TraceId traceId;
+  private final SpanId spanId;
+  private final Type type;
+
+  /**
+   * Returns a new {@code Link}.
+   *
+   * @param context the context of the linked {@code Span}.
+   * @param type the type of the relationship with the linked {@code Span}.
+   * @return a new {@code Link}.
+   */
+  public static Link fromSpanContext(SpanContext context, Type type) {
+    return new Link(context.getTraceId(), context.getSpanId(), type);
+  }
+
+  /**
+   * Returns the {@code TraceId}.
+   *
+   * @return the {@code TraceId}.
+   */
+  public TraceId getTraceId() {
+    return traceId;
+  }
+
+  /**
+   * Returns the {@code SpanId}.
+   *
+   * @return the {@code SpanId}
+   */
+  public SpanId getSpanId() {
+    return spanId;
+  }
+
+  /**
+   * Returns the {@code Type}.
+   *
+   * @return the {@code Type}.
+   */
+  public Type getType() {
+    return type;
+  }
+
+  private Link(TraceId traceId, SpanId spanId, Type type) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.type = type;
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/trace/Span.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Span.java
@@ -54,8 +54,8 @@ public abstract class Span {
   /**
    * Creates a new {@code Span}.
    *
-   * @param context The context associated with this {@code Span}.
-   * @param options The options associated with this {@code Span}. If {@code null} then default
+   * @param context the context associated with this {@code Span}.
+   * @param options the options associated with this {@code Span}. If {@code null} then default
    *     options will be set.
    * @throws NullPointerException if context is {@code null}.
    * @throws IllegalArgumentException if the {@code SpanContext} is sampled but no RECORD_EVENTS
@@ -73,25 +73,32 @@ public abstract class Span {
   /**
    * Adds a set of attributes to the {@code Span}.
    *
-   * @param attributes The attributes that will be added and associated with the {@code Span}.
+   * @param attributes the attributes that will be added and associated with the {@code Span}.
    */
   public abstract void addAttributes(Attributes attributes);
 
   /**
    * Adds an annotation to the {@code Span}.
    *
-   * @param description The description of the annotation time event.
+   * @param description the description of the annotation time event.
    */
   public abstract void addAnnotation(String description);
 
   /**
    * Adds an annotation to the {@code Span}.
    *
-   * @param description The description of the annotation time event.
-   * @param attributes The attributes that will be added; these are associated with this annotation,
+   * @param description the description of the annotation time event.
+   * @param attributes the attributes that will be added; these are associated with this annotation,
    *     not the {@code Span} as for {@link #addAttributes}.
    */
   public abstract void addAnnotation(String description, Attributes attributes);
+
+  /**
+   * Adds an annotation to the {@code Span}.
+   *
+   * @param annotation the annotations to add.
+   */
+  public abstract void addAnnotation(Annotation annotation);
 
   /**
    * Adds a NetworkEvent to the {@code Span}.
@@ -99,19 +106,19 @@ public abstract class Span {
    * <p>This function is only intended to be used by RPC systems (either client or server), not by
    * higher level applications.
    *
-   * @param networkEvent The network event to add.
+   * @param networkEvent the network event to add.
    */
   public abstract void addNetworkEvent(NetworkEvent networkEvent);
 
   /**
-   * Adds a child link to the {@code Span}.
+   * Adds a {@link Link} to the {@code Span}.
    *
    * <p>Used (for example) in batching operations, where a single batch handler processes multiple
    * requests from different traces.
    *
-   * @param childLink The child link to add.
+   * @param link the link to add.
    */
-  public abstract void addChildLink(Span childLink);
+  public abstract void addLink(Link link);
 
   /**
    * Marks the end of {@code Span} execution with the given options.
@@ -119,7 +126,7 @@ public abstract class Span {
    * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
    * implementations are free to ignore all further calls.
    *
-   * @param options The options to be used for the end of the {@code Span}.
+   * @param options the options to be used for the end of the {@code Span}.
    */
   public abstract void end(EndSpanOptions options);
 

--- a/core/src/test/java/com/google/instrumentation/trace/AnnotationTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/AnnotationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Link}. */
+@RunWith(JUnit4.class)
+public class AnnotationTest {
+  @Test(expected = NullPointerException.class)
+  public void fromDescription_NullDescription() {
+    Annotation.fromDescription(null);
+  }
+
+  @Test
+  public void fromDescription() {
+    Annotation annotation = Annotation.fromDescription("MyAnnotationText");
+    assertThat(annotation.getDescription()).isEqualTo("MyAnnotationText");
+    assertThat(annotation.getAttributes().getAll().size()).isEqualTo(0);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void fromDescriptionAndAttributes_NullDescription() {
+    Annotation.fromDescriptionAndAttributes(null, Attributes.EMPTY);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void fromDescriptionAndAttributes_NullAttributes() {
+    Annotation.fromDescriptionAndAttributes("", null);
+  }
+
+  @Test
+  public void fromDescriptionAndAttributes() {
+    Attributes attributes =
+        Attributes.builder()
+            .putStringAttribute("MyStringAttributeKey", "MyStringAttributeValue")
+            .build();
+    Annotation annotation = Annotation.fromDescriptionAndAttributes("MyAnnotationText", attributes);
+    assertThat(annotation.getDescription()).isEqualTo("MyAnnotationText");
+    assertThat(annotation.getAttributes().getAll()).isEqualTo(attributes.getAll());
+  }
+
+  @Test
+  public void fromDescriptionAndAttributes_EmptyAttributes() {
+    Annotation annotation =
+        Annotation.fromDescriptionAndAttributes("MyAnnotationText", Attributes.EMPTY);
+    assertThat(annotation.getDescription()).isEqualTo("MyAnnotationText");
+    assertThat(annotation.getAttributes().getAll().size()).isEqualTo(0);
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/trace/AttributeValueTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/AttributeValueTest.java
@@ -54,9 +54,11 @@ public class AttributeValueTest {
         AttributeValue.stringAttributeValue("MyStringAttributeValue"),
         AttributeValue.stringAttributeValue("MyStringAttributeValue"));
     tester.addEqualityGroup(AttributeValue.stringAttributeValue("MyStringAttributeDiffValue"));
-    tester.addEqualityGroup(AttributeValue.booleanAttributeValue(true), AttributeValue.booleanAttributeValue(true));
+    tester.addEqualityGroup(
+        AttributeValue.booleanAttributeValue(true), AttributeValue.booleanAttributeValue(true));
     tester.addEqualityGroup(AttributeValue.booleanAttributeValue(false));
-    tester.addEqualityGroup(AttributeValue.longAttributeValue(123456L), AttributeValue.longAttributeValue(123456L));
+    tester.addEqualityGroup(
+        AttributeValue.longAttributeValue(123456L), AttributeValue.longAttributeValue(123456L));
     tester.addEqualityGroup(AttributeValue.longAttributeValue(1234567L));
     tester.testEquals();
   }

--- a/core/src/test/java/com/google/instrumentation/trace/AttributesTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/AttributesTest.java
@@ -15,6 +15,8 @@ package com.google.instrumentation.trace;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,11 +27,34 @@ public class AttributesTest {
   @Test
   public void putStringAttribute() {
     Attributes attributes =
-        Attributes.builder().putStringAttribute("MyStringAttributeKey", "MyStringAttributeValue").build();
+        Attributes.builder()
+            .putStringAttribute("MyStringAttributeKey", "MyStringAttributeValue")
+            .build();
     assertThat(attributes.getAll().size()).isEqualTo(1);
     assertThat(attributes.getAll().containsKey("MyStringAttributeKey")).isTrue();
     assertThat(attributes.getAttributeValue("MyStringAttributeKey"))
         .isEqualTo(AttributeValue.stringAttributeValue("MyStringAttributeValue"));
+  }
+
+  @Test
+  public void emptyAttributes() {
+    assertThat(Attributes.EMPTY.getAll().size()).isEqualTo(0);
+    assertThat(Attributes.builder().build().getAll().size()).isEqualTo(0);
+  }
+
+  @Test
+  public void fromMap() {
+    Map<String, AttributeValue> attributes = new HashMap<String, AttributeValue>();
+    attributes.put(
+        "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
+    attributes.put("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
+    attributes.put("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
+    assertThat(Attributes.fromMap(attributes).getAll()).isEqualTo(attributes);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void fromMap_NullRepresentation() {
+    Attributes.fromMap(null);
   }
 
   @Test(expected = NullPointerException.class)
@@ -44,7 +69,8 @@ public class AttributesTest {
 
   @Test
   public void putBooleanAttribute() {
-    Attributes attributes = Attributes.builder().putBooleanAttribute("MyBooleanAttributeKey", true).build();
+    Attributes attributes =
+        Attributes.builder().putBooleanAttribute("MyBooleanAttributeKey", true).build();
     assertThat(attributes.getAll().size()).isEqualTo(1);
     assertThat(attributes.getAll().containsKey("MyBooleanAttributeKey")).isTrue();
     assertThat(attributes.getAttributeValue("MyBooleanAttributeKey"))
@@ -58,10 +84,12 @@ public class AttributesTest {
 
   @Test
   public void putLongAttribute() {
-    Attributes attributes = Attributes.builder().putLongAttribute("MyLongAttributeKey", 123L).build();
+    Attributes attributes =
+        Attributes.builder().putLongAttribute("MyLongAttributeKey", 123L).build();
     assertThat(attributes.getAll().size()).isEqualTo(1);
     assertThat(attributes.getAll().containsKey("MyLongAttributeKey")).isTrue();
-    assertThat(attributes.getAttributeValue("MyLongAttributeKey")).isEqualTo(AttributeValue.longAttributeValue(123L));
+    assertThat(attributes.getAttributeValue("MyLongAttributeKey"))
+        .isEqualTo(AttributeValue.longAttributeValue(123L));
   }
 
   @Test(expected = NullPointerException.class)
@@ -93,7 +121,8 @@ public class AttributesTest {
     assertThat(attributes.getAttributeValue("MyBooleanAttributeKey"))
         .isEqualTo(AttributeValue.booleanAttributeValue(true));
     assertThat(attributes.getAll().containsKey("MyLongAttributeKey")).isTrue();
-    assertThat(attributes.getAttributeValue("MyLongAttributeKey")).isEqualTo(AttributeValue.longAttributeValue(123L));
+    assertThat(attributes.getAttributeValue("MyLongAttributeKey"))
+        .isEqualTo(AttributeValue.longAttributeValue(123L));
   }
 
   @Test
@@ -105,7 +134,8 @@ public class AttributesTest {
             .build();
     assertThat(attributes.getAll().size()).isEqualTo(1);
     assertThat(attributes.getAll().containsKey("MyAttributeKey")).isTrue();
-    assertThat(attributes.getAttributeValue("MyAttributeKey")).isEqualTo(AttributeValue.longAttributeValue(123L));
+    assertThat(attributes.getAttributeValue("MyAttributeKey"))
+        .isEqualTo(AttributeValue.longAttributeValue(123L));
   }
 
   @Test
@@ -118,9 +148,11 @@ public class AttributesTest {
             .build();
     assertThat(attributes.getAll().size()).isEqualTo(3);
     assertThat(attributes.getAll().containsKey("MyLongAttributeKey1")).isTrue();
-    assertThat(attributes.getAttributeValue("MyLongAttributeKey1")).isEqualTo(AttributeValue.longAttributeValue(1L));
+    assertThat(attributes.getAttributeValue("MyLongAttributeKey1"))
+        .isEqualTo(AttributeValue.longAttributeValue(1L));
     assertThat(attributes.getAll().containsKey("MyLongAttributeKey12")).isTrue();
-    assertThat(attributes.getAttributeValue("MyLongAttributeKey12")).isEqualTo(AttributeValue.longAttributeValue(12L));
+    assertThat(attributes.getAttributeValue("MyLongAttributeKey12"))
+        .isEqualTo(AttributeValue.longAttributeValue(12L));
     assertThat(attributes.getAll().containsKey("MyLongAttributeKey123")).isTrue();
     assertThat(attributes.getAttributeValue("MyLongAttributeKey123"))
         .isEqualTo(AttributeValue.longAttributeValue(123L));
@@ -129,13 +161,16 @@ public class AttributesTest {
   @Test
   public void attributes_ToString() {
     Attributes attributes =
-        Attributes.builder().putStringAttribute("MyStringAttributeKey", "MyStringAttributeValue").build();
+        Attributes.builder()
+            .putStringAttribute("MyStringAttributeKey", "MyStringAttributeValue")
+            .build();
     assertThat(attributes.toString()).contains("MyStringAttributeKey");
     assertThat(attributes.toString())
         .contains(AttributeValue.stringAttributeValue("MyStringAttributeValue").toString());
     attributes = Attributes.builder().putBooleanAttribute("MyBooleanAttributeKey", true).build();
     assertThat(attributes.toString()).contains("MyBooleanAttributeKey");
-    assertThat(attributes.toString()).contains(AttributeValue.booleanAttributeValue(true).toString());
+    assertThat(attributes.toString())
+        .contains(AttributeValue.booleanAttributeValue(true).toString());
     attributes = Attributes.builder().putLongAttribute("MyLongAttributeKey", 123L).build();
     assertThat(attributes.toString()).contains("MyLongAttributeKey");
     assertThat(attributes.toString()).contains(AttributeValue.longAttributeValue(123L).toString());

--- a/core/src/test/java/com/google/instrumentation/trace/BlankSpanTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/BlankSpanTest.java
@@ -35,10 +35,13 @@ public class BlankSpanTest {
         Attributes.builder().putStringAttribute("MyAttributeKey", "MyAttributeValue").build());
     BlankSpan.INSTANCE.addAnnotation("MyAnnotation");
     BlankSpan.INSTANCE.addAnnotation(
-        "MyAnnotation", Attributes.builder().putStringAttribute("MyAttributeKey", "MyAttributeValue").build());
+        "MyAnnotation",
+        Attributes.builder().putStringAttribute("MyAttributeKey", "MyAttributeValue").build());
+    BlankSpan.INSTANCE.addAnnotation(Annotation.fromDescription("MyAnnotation"));
     BlankSpan.INSTANCE.addNetworkEvent(NetworkEvent.builder(NetworkEvent.Type.SENT, 1L).build());
-    BlankSpan.INSTANCE.addChildLink(BlankSpan.INSTANCE);
+    BlankSpan.INSTANCE.addLink(Link.fromSpanContext(SpanContext.INVALID, Link.Type.CHILD));
     BlankSpan.INSTANCE.end(EndSpanOptions.DEFAULT);
+    BlankSpan.INSTANCE.end();
   }
 
   @Test

--- a/core/src/test/java/com/google/instrumentation/trace/HttpPropagationUtilTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/HttpPropagationUtilTest.java
@@ -77,8 +77,8 @@ public class HttpPropagationUtilTest {
 
   @Test
   public void toHttpHeaderValue_InvalidSpanContext() {
-    assertThat(HttpPropagationUtil.toHttpHeaderValue(SpanContext.INVALID)).isEqualTo
-        ("0000000000000000000000000000000000000000000000000000000000");
+    assertThat(HttpPropagationUtil.toHttpHeaderValue(SpanContext.INVALID))
+        .isEqualTo("0000000000000000000000000000000000000000000000000000000000");
   }
 
   @Test

--- a/core/src/test/java/com/google/instrumentation/trace/LinkTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/LinkTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.instrumentation.trace.Link.Type;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Link}. */
+@RunWith(JUnit4.class)
+public class LinkTest {
+  private Random random;
+  private SpanContext spanContext;
+
+  @Before
+  public void setUp() {
+    random = new Random(1234);
+    spanContext =
+        new SpanContext(
+            TraceId.generateRandomId(random),
+            SpanId.generateRandomId(random),
+            TraceOptions.DEFAULT);
+  }
+
+  @Test
+  public void fromSpanContext_ChildLink() {
+    Link link = Link.fromSpanContext(spanContext, Type.CHILD);
+    assertThat(link.getTraceId()).isEqualTo(spanContext.getTraceId());
+    assertThat(link.getSpanId()).isEqualTo(spanContext.getSpanId());
+    assertThat(link.getType()).isEqualTo(Type.CHILD);
+  }
+
+  @Test
+  public void fromSpanContext_ParentLink() {
+    Link link = Link.fromSpanContext(spanContext, Type.PARENT);
+    assertThat(link.getTraceId()).isEqualTo(spanContext.getTraceId());
+    assertThat(link.getSpanId()).isEqualTo(spanContext.getSpanId());
+    assertThat(link.getType()).isEqualTo(Type.PARENT);
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
@@ -100,10 +100,13 @@ public class SpanTest {
     public void addAnnotation(String description, Attributes attributes) {}
 
     @Override
+    public void addAnnotation(Annotation annotation) {}
+
+    @Override
     public void addNetworkEvent(NetworkEvent networkEvent) {}
 
     @Override
-    public void addChildLink(Span childLink) {}
+    public void addLink(Link link) {}
 
     @Override
     public void end(EndSpanOptions options) {}


### PR DESCRIPTION
Change Span to accept Links and Annotations.

This change allows to expose later an interface to export SpanData without depending on protos which is mandatory when using Stackdriver tracer.