### PR TITLE
Add build rule for examples to generate executable binaries.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -11,4 +11,43 @@ dependencies {
             libraries.grpc_context
 }
 
-// TODO(bdrutu): Add application plugin and create jars for each example.
+// Provide convenience executables for trying out the examples.
+apply plugin: 'application'
+
+startScripts.enabled = false
+
+task statsRunner(type: CreateStartScripts) {
+    mainClassName = 'com.google.instrumentation.trace.examples.StatsRunner'
+    applicationName = 'StatsRunner'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+task multiSpansTracing(type: CreateStartScripts) {
+    mainClassName = 'com.google.instrumentation.trace.examples.MultiSpansTracing'
+    applicationName = 'MultiSpansTracing'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+task multiSpansScopedTracing(type: CreateStartScripts) {
+    mainClassName = 'com.google.instrumentation.trace.examples.MultiSpansScopedTracing'
+    applicationName = 'MultiSpansScopedTracing'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+task multiSpansContextTracing(type: CreateStartScripts) {
+    mainClassName = 'com.google.instrumentation.trace.examples.MultiSpansContextTracing'
+    applicationName = 'MultiSpansContextTracing'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+applicationDistribution.into('bin') {
+    from(multiSpansTracing)
+    from(multiSpansScopedTracing)
+    from(multiSpansContextTracing)
+    from(statsRunner)
+    fileMode = 0755
+}

--- a/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
@@ -11,10 +11,16 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.stats;
+package com.google.instrumentation.examples.stats;
 
+import com.google.instrumentation.stats.MeasurementDescriptor;
 import com.google.instrumentation.stats.MeasurementDescriptor.BasicUnit;
 import com.google.instrumentation.stats.MeasurementDescriptor.MeasurementUnit;
+import com.google.instrumentation.stats.MeasurementMap;
+import com.google.instrumentation.stats.Stats;
+import com.google.instrumentation.stats.StatsContext;
+import com.google.instrumentation.stats.TagKey;
+import com.google.instrumentation.stats.TagValue;
 import io.grpc.Context;
 import java.util.Arrays;
 

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/BasicContextTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/BasicContextTracing.java
@@ -11,15 +11,17 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
 
 /**
- * Example showing how to create a {@link Span} using {@link ScopedSpan}, install it in the current
- * context, and add annotations.
+ * Example showing how to create a {@link Span}, install it to the current context and add
+ * annotations.
  */
-public final class BasicScopedTracing {
+public final class BasicContextTracing {
   // Per class Tracer.
   private static final Tracer tracer = Tracer.getTracer();
 
@@ -30,9 +32,10 @@ public final class BasicScopedTracing {
 
   /** Main method. */
   public static void main(String[] args) {
-    try (NonThrowingCloseable ss =
-        tracer.spanBuilder("MyRootSpan").becomeRoot().startScopedSpan()) {
+    Span span = tracer.spanBuilder("MyRootSpan").becomeRoot().startSpan();
+    try (NonThrowingCloseable ws = tracer.withSpan(span)) {
       doWork();
     }
+    span.end();
   }
 }

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/BasicScopedTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/BasicScopedTracing.java
@@ -11,21 +11,30 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
-/** Example showing how to create a {@link Span} and add annotations. */
-public final class BasicTracing {
+import com.google.instrumentation.common.NonThrowingCloseable;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
+
+/**
+ * Example showing how to create a {@link Span} using scoped Span, install it in the current
+ * context, and add annotations.
+ */
+public final class BasicScopedTracing {
   // Per class Tracer.
   private static final Tracer tracer = Tracer.getTracer();
 
   private static void doWork() {
-    Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan();
-    span.addAnnotation("This annotation is added directly to the span.");
-    span.end();
+    // Add an annotation to the current Span.
+    tracer.getCurrentSpan().addAnnotation("This is a doWork() annotation.");
   }
 
   /** Main method. */
   public static void main(String[] args) {
-    doWork();
+    try (NonThrowingCloseable ss =
+        tracer.spanBuilder("MyRootSpan").becomeRoot().startScopedSpan()) {
+      doWork();
+    }
   }
 }

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/BasicTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/BasicTracing.java
@@ -11,21 +11,20 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
-/** Example showing how to directly create a child {@link Span} and add annotations. */
-public final class MultiSpansTracing {
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
+
+/** Example showing how to create a {@link Span} and add annotations. */
+public final class BasicTracing {
   // Per class Tracer.
   private static final Tracer tracer = Tracer.getTracer();
 
   private static void doWork() {
-    Span rootSpan = tracer.spanBuilder(null, "MyRootSpan").startSpan();
-    rootSpan.addAnnotation("Annotation to the root Span before child is created.");
-    Span childSpan = tracer.spanBuilder(rootSpan, "MyChildSpan").startSpan();
-    childSpan.addAnnotation("Annotation to the child Span");
-    childSpan.end();
-    rootSpan.addAnnotation("Annotation to the root Span after child is ended.");
-    rootSpan.end();
+    Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+    span.addAnnotation("This annotation is added directly to the span.");
+    span.end();
   }
 
   /** Main method. */

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansContextTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansContextTracing.java
@@ -11,9 +11,11 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
 
 /**
  * Example showing how to create a child {@link Span}, install it to the current context and add

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansScopedTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansScopedTracing.java
@@ -11,12 +11,14 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
 
 /**
- * Example showing how to create a child {@link Span} using {@link ScopedSpan}, install it in the
+ * Example showing how to create a child {@link Span} using scoped Spans, install it in the
  * current context, and add annotations.
  */
 public final class MultiSpansScopedTracing {

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansTracing.java
@@ -11,29 +11,28 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.trace;
+package com.google.instrumentation.examples.trace;
 
-import com.google.instrumentation.common.NonThrowingCloseable;
+import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.Tracer;
 
-/**
- * Example showing how to create a {@link Span}, install it to the current context and add
- * annotations.
- */
-public final class BasicContextTracing {
+/** Example showing how to directly create a child {@link Span} and add annotations. */
+public final class MultiSpansTracing {
   // Per class Tracer.
   private static final Tracer tracer = Tracer.getTracer();
 
   private static void doWork() {
-    // Add an annotation to the current Span.
-    tracer.getCurrentSpan().addAnnotation("This is a doWork() annotation.");
+    Span rootSpan = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+    rootSpan.addAnnotation("Annotation to the root Span before child is created.");
+    Span childSpan = tracer.spanBuilder(rootSpan, "MyChildSpan").startSpan();
+    childSpan.addAnnotation("Annotation to the child Span");
+    childSpan.end();
+    rootSpan.addAnnotation("Annotation to the root Span after child is ended.");
+    rootSpan.end();
   }
 
   /** Main method. */
   public static void main(String[] args) {
-    Span span = tracer.spanBuilder("MyRootSpan").becomeRoot().startSpan();
-    try (NonThrowingCloseable ws = tracer.withSpan(span)) {
-      doWork();
-    }
-    span.end();
+    doWork();
   }
 }


### PR DESCRIPTION
Fix javadoc errors in examples.
Move all the examples in a different package than the implementation to avoid using (by mistake) package-protected methods that others cannot use. 