### PR TITLE
Gradle plugin making it easier/safer to use Java annotation processors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.3.0'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.9'
+        classpath "net.ltgt.gradle:gradle-apt-plugin:0.10"
     }
 }
 
@@ -22,6 +23,7 @@ subprojects {
     // The plugin only has an effect if a signature is specified
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'findbugs'
+    apply plugin: "net.ltgt.apt"
     // Plugins that require java8
     if (JavaVersion.current().isJava8Compatible()) {
         // TODO(bdrutu): enable all checks.


### PR DESCRIPTION
Helps IDEs to recognize the auto-generated files.