### PR TITLE
Only load one stats class with reflection.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/Stats.java
+++ b/core/src/main/java/com/google/instrumentation/stats/Stats.java
@@ -19,17 +19,17 @@ import com.google.instrumentation.common.Provider;
  * {@link Stats}.
  */
 public final class Stats {
-  private static final StatsContextFactory CONTEXT_FACTORY = Provider.newInstance(
-      "com.google.instrumentation.stats.StatsContextFactoryImpl", null);
-
   private static final StatsManager STATS_MANAGER = Provider.newInstance(
       "com.google.instrumentation.stats.StatsManagerImpl", null);
 
   /**
    * Returns the default {@link StatsContextFactory}.
+   *
+   * @deprecated Use {@link StatsManager#getStatsContextFactory()} instead.
    */
+  @Deprecated
   public static StatsContextFactory getStatsContextFactory() {
-    return CONTEXT_FACTORY;
+    return STATS_MANAGER.getStatsContextFactory();
   }
 
   /**

--- a/core/src/main/java/com/google/instrumentation/stats/Stats.java
+++ b/core/src/main/java/com/google/instrumentation/stats/Stats.java
@@ -19,7 +19,7 @@ import com.google.instrumentation.common.Provider;
  * {@link Stats}.
  */
 public final class Stats {
-  private static final StatsManager STATS_MANAGER = Provider.newInstance(
+  private static final StatsManager statsManager = Provider.newInstance(
       "com.google.instrumentation.stats.StatsManagerImpl", null);
 
   /**
@@ -29,14 +29,14 @@ public final class Stats {
    */
   @Deprecated
   public static StatsContextFactory getStatsContextFactory() {
-    return STATS_MANAGER.getStatsContextFactory();
+    return statsManager.getStatsContextFactory();
   }
 
   /**
    * Returns the default {@link StatsManager}.
    */
   public static StatsManager getStatsManager() {
-    return STATS_MANAGER;
+    return statsManager;
   }
 
   // VisibleForTesting

--- a/core/src/main/java/com/google/instrumentation/stats/Stats.java
+++ b/core/src/main/java/com/google/instrumentation/stats/Stats.java
@@ -24,10 +24,7 @@ public final class Stats {
 
   /**
    * Returns the default {@link StatsContextFactory}.
-   *
-   * @deprecated Use {@link StatsManager#getStatsContextFactory()} instead.
    */
-  @Deprecated
   public static StatsContextFactory getStatsContextFactory() {
     return statsManager.getStatsContextFactory();
   }

--- a/core/src/main/java/com/google/instrumentation/stats/StatsManager.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsManager.java
@@ -28,4 +28,9 @@ public abstract class StatsManager {
    * Returns the current stats data, {@link View}, associated with the given {@link ViewDescriptor}.
    */
   public abstract View getView(ViewDescriptor viewDescriptor);
+
+  /**
+   * Returns the default {@link StatsContextFactory}.
+   */
+  public abstract StatsContextFactory getStatsContextFactory();
 }

--- a/core/src/main/java/com/google/instrumentation/stats/StatsManager.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsManager.java
@@ -32,5 +32,5 @@ public abstract class StatsManager {
   /**
    * Returns the default {@link StatsContextFactory}.
    */
-  public abstract StatsContextFactory getStatsContextFactory();
+  abstract StatsContextFactory getStatsContextFactory();
 }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
@@ -20,10 +20,8 @@ import java.util.HashMap;
 /**
  * Native Implementation of {@link StatsContextFactory}.
  */
-public final class StatsContextFactoryImpl extends StatsContextFactory {
+final class StatsContextFactoryImpl extends StatsContextFactory {
   static final StatsContextImpl DEFAULT = new StatsContextImpl(new HashMap<String, String>(0));
-
-  public StatsContextFactoryImpl() {}
 
   /**
    * Deserializes a {@link StatsContextImpl} from a serialized {@code CensusContextProto}.

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+/**
+ * Native Implementation of {@link StatsManager}.
+ */
+public final class StatsManagerImpl extends StatsManager {
+
+  private final StatsContextFactoryImpl statsContextFactory = new StatsContextFactoryImpl();
+
+  @Override
+  public void registerView(ViewDescriptor viewDescriptor) {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+  @Override
+  public View getView(ViewDescriptor viewDescriptor) {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+  @Override
+  public StatsContextFactoryImpl getStatsContextFactory() {
+    return statsContextFactory;
+  }
+}

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -31,7 +31,7 @@ public final class StatsManagerImpl extends StatsManager {
   }
 
   @Override
-  public StatsContextFactoryImpl getStatsContextFactory() {
+  StatsContextFactoryImpl getStatsContextFactory() {
     return statsContextFactory;
   }
 }

--- a/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
@@ -72,8 +72,7 @@ public class StatsRunner {
     System.out.println("Current == Default: " + getCurrentStatsContext().equals(DEFAULT));
   }
 
-  private static final StatsContext DEFAULT =
-      Stats.getStatsManager().getStatsContextFactory().getDefault();
+  private static final StatsContext DEFAULT = Stats.getStatsContextFactory().getDefault();
 
   private static final Context.Key<StatsContext> STATS_CONTEXT_KEY =
       Context.keyWithDefault("StatsContextKey", DEFAULT);

--- a/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/stats/StatsRunner.java
@@ -72,7 +72,8 @@ public class StatsRunner {
     System.out.println("Current == Default: " + getCurrentStatsContext().equals(DEFAULT));
   }
 
-  private static final StatsContext DEFAULT = Stats.getStatsContextFactory().getDefault();
+  private static final StatsContext DEFAULT =
+      Stats.getStatsManager().getStatsContextFactory().getDefault();
 
   private static final Context.Key<StatsContext> STATS_CONTEXT_KEY =
       Context.keyWithDefault("StatsContextKey", DEFAULT);


### PR DESCRIPTION
Previously, the `Stats` class used reflection to instantiate subclasses for both
`StatsManager` and `StatsContextFactory`.  That design forced the `StatsManager`
and `StatsContextFactory` subclasses to only interact through their public APIs.

This commit changes `Stats` so that it only instantiates `StatsManager`.  The
`StatsManager` instance then creates the one `StatsContextFactory` instance by
calling a constructor.  The main difference is that `StatsManager` now knows
what subclass of `StatsContextFactory` is in use, and all of the stats
implementation classes can interact through package-private methods.