### PR TITLE
Remove start/end timestamps from our public interface.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/trace/EndSpanOptions.java
+++ b/core/src/main/java/com/google/instrumentation/trace/EndSpanOptions.java
@@ -17,24 +17,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.instrumentation.common.Timestamp;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
  * A class that enables overriding the default values used when ending a {@link Span}. Allows
- * overriding the {@link Status status} and the {@link Timestamp end time}.
+ * overriding the {@link Status status}.
  */
 @Immutable
 public final class EndSpanOptions {
   private final Status status;
-  private final Timestamp endTime;
 
   /** The default {@code EndSpanOptions}. */
   public static final EndSpanOptions DEFAULT = builder().build();
 
-  private EndSpanOptions(Timestamp endTime, Status status) {
-    this.endTime = endTime;
+  private EndSpanOptions(Status status) {
     this.status = status;
   }
 
@@ -45,16 +42,6 @@ public final class EndSpanOptions {
    */
   public static Builder builder() {
     return new Builder();
-  }
-
-  /**
-   * Returns the end time or {@code null} if default.
-   *
-   * @return the end time or {@code null} if default.
-   */
-  @Nullable
-  public Timestamp getEndTime() {
-    return endTime;
   }
 
   /**
@@ -77,42 +64,26 @@ public final class EndSpanOptions {
     }
 
     EndSpanOptions that = (EndSpanOptions) obj;
-    return Objects.equal(endTime, that.endTime) && Objects.equal(status, that.status);
+    return Objects.equal(status, that.status);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(endTime, status);
+    return Objects.hashCode(status);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("endTime", endTime)
         .add("status", status)
         .toString();
   }
 
   /** Builder class for {@link EndSpanOptions}. */
   public static final class Builder {
-    private Timestamp endTime;
     private Status status = Status.OK;
 
     private Builder() {}
-
-    /**
-     * Sets the end time for the {@link Span}.
-     *
-     * <p>If not {@code null}, this will override the {@link Span} end time.
-     *
-     * @param endTime a timestamp used as the {@code Span} end time; if {@code null}, the default
-     *     (system time at which the {@link Span#end} method was called) will be used.
-     * @return this.
-     */
-    public Builder setEndTime(@Nullable Timestamp endTime) {
-      this.endTime = endTime;
-      return this;
-    }
 
     /**
      * Sets the status for the {@link Span}.
@@ -134,7 +105,7 @@ public final class EndSpanOptions {
      * @return a {@code EndSpanOptions} with the desired settings.
      */
     public EndSpanOptions build() {
-      return new EndSpanOptions(endTime, status);
+      return new EndSpanOptions(status);
     }
   }
 }

--- a/core/src/main/java/com/google/instrumentation/trace/SpanBuilder.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanBuilder.java
@@ -14,7 +14,6 @@
 package com.google.instrumentation.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
-import com.google.instrumentation.common.Timestamp;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -115,18 +114,6 @@ public final class SpanBuilder {
     this.hasRemoteParent = hasRemoteParent;
     this.name = name;
     this.spanFactory = spanFactory;
-  }
-
-  /**
-   * Sets the start time for the {@link Span}.
-   *
-   * @param startTime The start time for the {@code Span}. If {@code null} is used, then the current
-   *     system time at the point at which {@link #startSpan} is called will be used.
-   * @return this.
-   */
-  public SpanBuilder setStartTime(@Nullable Timestamp startTime) {
-    startSpanOption.setStartTime(startTime);
-    return this;
   }
 
   /**

--- a/core/src/main/java/com/google/instrumentation/trace/StartSpanOptions.java
+++ b/core/src/main/java/com/google/instrumentation/trace/StartSpanOptions.java
@@ -14,37 +14,24 @@
 package com.google.instrumentation.trace;
 
 import com.google.common.base.Objects;
-import com.google.instrumentation.common.Timestamp;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
 /**
  * A class that enables overriding the default values used when starting a {@link Span}. Allows
- * overriding the {@link Timestamp start time}, the {@link Sampler sampler}, the parent links, and
- * option to record all the events even if the {@code Span} is not sampled.
+ * overriding the {@link Sampler sampler}, the parent links, and option to record all the events
+ * even if the {@code Span} is not sampled.
  */
 final class StartSpanOptions {
-  private Timestamp startTime;
   private Sampler sampler;
   private List<Span> parentLinks;
   private Boolean recordEvents;
 
   StartSpanOptions() {
-    this.startTime = null;
     this.sampler = null;
     this.parentLinks = null;
     this.recordEvents = null;
-  }
-
-  /**
-   * Returns start time to be used, or {@code null} if default.
-   *
-   * @return start time to be used, or {@code null} if default.
-   */
-  @Nullable
-  Timestamp getStartTime() {
-    return startTime;
   }
 
   /**
@@ -90,19 +77,14 @@ final class StartSpanOptions {
     }
 
     StartSpanOptions that = (StartSpanOptions) obj;
-    return Objects.equal(startTime, that.startTime)
-        && Objects.equal(sampler, that.sampler)
+    return Objects.equal(sampler, that.sampler)
         && Objects.equal(parentLinks, that.parentLinks)
         && Objects.equal(recordEvents, that.recordEvents);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(startTime, sampler, parentLinks, recordEvents);
-  }
-
-  void setStartTime(@Nullable Timestamp startTime) {
-    this.startTime = startTime;
+    return Objects.hashCode(sampler, parentLinks, recordEvents);
   }
 
   void setSampler(@Nullable Sampler sampler) {

--- a/core/src/test/java/com/google/instrumentation/trace/EndSpanOptionsTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/EndSpanOptionsTest.java
@@ -16,7 +16,6 @@ package com.google.instrumentation.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import com.google.instrumentation.common.Timestamp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -32,42 +31,26 @@ public class EndSpanOptionsTest {
   @Test
   public void endSpanOptions_DefaultOptions() {
     assertThat(EndSpanOptions.DEFAULT.getStatus()).isEqualTo(Status.OK);
-    assertThat(EndSpanOptions.DEFAULT.getEndTime()).isNull();
   }
 
   @Test
-  public void setEndTimestamp() {
-    EndSpanOptions endSpanOptions =
-        EndSpanOptions.builder().setEndTime(Timestamp.fromMillis(123456L)).build();
-    assertThat(endSpanOptions.getStatus()).isEqualTo(Status.OK);
-    assertThat(endSpanOptions.getEndTime()).isEqualTo(Timestamp.fromMillis(123456L));
-  }
-
-  @Test
-  public void setTimestampAndStatus() {
+  public void setStatus() {
     EndSpanOptions endSpanOptions =
         EndSpanOptions.builder()
-            .setEndTime(Timestamp.fromMillis(123456L))
             .setStatus(Status.CANCELLED.withDescription("ThisIsAnError"))
             .build();
     assertThat(endSpanOptions.getStatus())
         .isEqualTo(Status.CANCELLED.withDescription("ThisIsAnError"));
-    assertThat(endSpanOptions.getEndTime()).isEqualTo(Timestamp.fromMillis(123456L));
   }
 
   @Test
   public void endSpanOptions_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
     tester.addEqualityGroup(
-        EndSpanOptions.builder().setEndTime(Timestamp.fromMillis(123456L)).build(),
-        EndSpanOptions.builder().setEndTime(Timestamp.fromMillis(123456L)).build());
-    tester.addEqualityGroup(
         EndSpanOptions.builder()
-            .setEndTime(Timestamp.fromMillis(123456L))
             .setStatus(Status.CANCELLED.withDescription("ThisIsAnError"))
             .build(),
         EndSpanOptions.builder()
-            .setEndTime(Timestamp.fromMillis(123456L))
             .setStatus(Status.CANCELLED.withDescription("ThisIsAnError"))
             .build());
     tester.addEqualityGroup(EndSpanOptions.builder().build(), EndSpanOptions.DEFAULT);
@@ -78,10 +61,8 @@ public class EndSpanOptionsTest {
   public void endSpanOptions_ToString() {
     EndSpanOptions endSpanOptions =
         EndSpanOptions.builder()
-            .setEndTime(Timestamp.fromMillis(123456L))
             .setStatus(Status.CANCELLED.withDescription("ThisIsAnError"))
             .build();
-    assertThat(endSpanOptions.toString()).contains(Timestamp.fromMillis(123456L).toString());
     assertThat(endSpanOptions.toString()).contains("ThisIsAnError");
   }
 }

--- a/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
-import com.google.instrumentation.common.Timestamp;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -73,7 +72,6 @@ public class SpanBuilderTest {
   public void startScopedSpanRootWithOptions() {
     StartSpanOptions startSpanOptions = new StartSpanOptions();
     startSpanOptions.setSampler(Samplers.neverSample());
-    startSpanOptions.setStartTime(Timestamp.fromMillis(1234567L));
     when(spanFactory.startSpan(
             isNull(SpanContext.class), eq(false), same(SPAN_NAME), eq(startSpanOptions)))
         .thenReturn(span);
@@ -81,7 +79,6 @@ public class SpanBuilderTest {
         spanBuilder
             .becomeRoot()
             .setSampler(Samplers.neverSample())
-            .setStartTime(Timestamp.fromMillis(1234567L))
             .startScopedSpan();
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);

--- a/core/src/test/java/com/google/instrumentation/trace/StartSpanOptionsTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/StartSpanOptionsTest.java
@@ -32,27 +32,15 @@ public class StartSpanOptionsTest {
   @Test
   public void defaultOptions() {
     StartSpanOptions defaultOptions = new StartSpanOptions();
-    assertThat(defaultOptions.getStartTime()).isNull();
     assertThat(defaultOptions.getSampler()).isNull();
     assertThat(defaultOptions.getParentLinks().isEmpty()).isTrue();
     assertThat(defaultOptions.getRecordEvents()).isNull();
   }
 
   @Test
-  public void setStartTime() {
-    StartSpanOptions options = new StartSpanOptions();
-    options.setStartTime(Timestamp.fromMillis(1234567L));
-    assertThat(options.getStartTime()).isEqualTo(Timestamp.fromMillis(1234567L));
-    assertThat(options.getSampler()).isNull();
-    assertThat(options.getParentLinks().isEmpty()).isTrue();
-    assertThat(options.getRecordEvents()).isNull();
-  }
-
-  @Test
   public void setSampler() {
     StartSpanOptions options = new StartSpanOptions();
     options.setSampler(Samplers.neverSample());
-    assertThat(options.getStartTime()).isNull();
     assertThat(options.getSampler()).isEqualTo(Samplers.neverSample());
     assertThat(options.getParentLinks().isEmpty()).isTrue();
     assertThat(options.getRecordEvents()).isNull();
@@ -62,7 +50,6 @@ public class StartSpanOptionsTest {
   public void setParentLinks() {
     StartSpanOptions options = new StartSpanOptions();
     options.setParentLinks(singleParentList);
-    assertThat(options.getStartTime()).isNull();
     assertThat(options.getSampler()).isNull();
     assertThat(options.getParentLinks()).isEqualTo(singleParentList);
     assertThat(options.getRecordEvents()).isNull();
@@ -72,7 +59,6 @@ public class StartSpanOptionsTest {
   public void setParentLinks_EmptyList() {
     StartSpanOptions options = new StartSpanOptions();
     options.setParentLinks(new LinkedList<Span>());
-    assertThat(options.getStartTime()).isNull();
     assertThat(options.getSampler()).isNull();
     assertThat(options.getParentLinks().size()).isEqualTo(0);
     assertThat(options.getRecordEvents()).isNull();
@@ -82,7 +68,6 @@ public class StartSpanOptionsTest {
   public void setParentLinks_MultipleParents() {
     StartSpanOptions options = new StartSpanOptions();
     options.setParentLinks(Arrays.<Span>asList(BlankSpan.INSTANCE, BlankSpan.INSTANCE));
-    assertThat(options.getStartTime()).isNull();
     assertThat(options.getSampler()).isNull();
     assertThat(options.getParentLinks().size()).isEqualTo(2);
     assertThat(options.getRecordEvents()).isNull();
@@ -92,7 +77,6 @@ public class StartSpanOptionsTest {
   public void setRecordEvents() {
     StartSpanOptions options = new StartSpanOptions();
     options.setRecordEvents(true);
-    assertThat(options.getStartTime()).isNull();
     assertThat(options.getSampler()).isNull();
     assertThat(options.getParentLinks().isEmpty()).isTrue();
     assertThat(options.getRecordEvents()).isTrue();
@@ -101,12 +85,10 @@ public class StartSpanOptionsTest {
   @Test
   public void setAllProperties() {
     StartSpanOptions options = new StartSpanOptions();
-    options.setStartTime(Timestamp.fromMillis(1234567L));
     options.setSampler(Samplers.neverSample());
     options.setSampler(Samplers.alwaysSample()); // second SetSampler should apply
     options.setRecordEvents(true);
     options.setParentLinks(singleParentList);
-    assertThat(options.getStartTime()).isEqualTo(Timestamp.fromMillis(1234567L));
     assertThat(options.getSampler()).isEqualTo(Samplers.alwaysSample());
     assertThat(options.getParentLinks()).isEqualTo(singleParentList);
     assertThat(options.getRecordEvents()).isTrue();
@@ -115,14 +97,11 @@ public class StartSpanOptionsTest {
   @Test
   public void startSpanOptions_EqualsAndHashCode() {
     EqualsTester tester = new EqualsTester();
-    StartSpanOptions optionsWithStartTime1 = new StartSpanOptions();
-    optionsWithStartTime1.setStartTime(Timestamp.fromMillis(1234567L));
-    StartSpanOptions optionsWithStartTime2 = new StartSpanOptions();
-    optionsWithStartTime2.setStartTime(Timestamp.fromMillis(1234567L));
-    tester.addEqualityGroup(optionsWithStartTime1, optionsWithStartTime2);
-    StartSpanOptions optionsWithAlwaysSampler = new StartSpanOptions();
-    optionsWithAlwaysSampler.setSampler(Samplers.alwaysSample());
-    tester.addEqualityGroup(optionsWithAlwaysSampler);
+    StartSpanOptions optionsWithAlwaysSampler1 = new StartSpanOptions();
+    optionsWithAlwaysSampler1.setSampler(Samplers.alwaysSample());
+    StartSpanOptions optionsWithAlwaysSampler2 = new StartSpanOptions();
+    optionsWithAlwaysSampler2.setSampler(Samplers.alwaysSample());
+    tester.addEqualityGroup(optionsWithAlwaysSampler1, optionsWithAlwaysSampler2);
     StartSpanOptions optionsWithNeverSampler = new StartSpanOptions();
     optionsWithNeverSampler.setSampler(Samplers.neverSample());
     tester.addEqualityGroup(optionsWithNeverSampler);


### PR DESCRIPTION
Until we have a better design on how are we going to support them we should not have this functionality in our public API.