### PR TITLE
Adds a class to represent a MeasurementDescriptor name.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
@@ -34,6 +34,14 @@ public abstract class MeasurementDescriptor {
    * Constructs a new {@link MeasurementDescriptor}.
    */
   public static MeasurementDescriptor create(
+      MeasurementDescriptor.Name name, String description, MeasurementUnit unit) {
+    return new AutoValue_MeasurementDescriptor(name.asString(), description, unit);
+  }
+
+  /**
+   * Constructs a new {@link MeasurementDescriptor}.
+   */
+  public static MeasurementDescriptor create(
       String name, String description, MeasurementUnit unit) {
     return new AutoValue_MeasurementDescriptor(StringUtil.sanitize(name), description, unit);
   }
@@ -41,6 +49,7 @@ public abstract class MeasurementDescriptor {
   /**
    * Name of measurement, e.g. rpc_latency, cpu. Must be unique.
    */
+  // TODO(sebright): Change the type of this field to MeasurementDescriptor.Name.
   public abstract String getName();
 
   /**
@@ -62,6 +71,33 @@ public abstract class MeasurementDescriptor {
     BYTES,
     SECONDS,
     CORES;
+  }
+
+  /**
+   * The name of a {@code MeasurementDescriptor}.
+   */
+  // This type should be used as the key when associating data with MeasurementDescriptors.
+  @AutoValue
+  public abstract static class Name {
+
+    Name() {}
+
+    /**
+     * Returns the name as a {@code String}.
+     *
+     * @return the name as a {@code String}.
+     */
+    public abstract String asString();
+
+    /**
+     * Creates a {@code MeasurementDescriptor.Name} from a {@code String}.
+     *
+     * @param name the name {@code String}.
+     * @return a {@code MeasurementDescriptor.Name} with the given name {@code String}.
+     */
+    public static Name create(String name) {
+      return new AutoValue_MeasurementDescriptor_Name(StringUtil.sanitize(name));
+    }
   }
 
   /**

--- a/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
@@ -34,23 +34,29 @@ public abstract class MeasurementDescriptor {
    * Constructs a new {@link MeasurementDescriptor}.
    */
   public static MeasurementDescriptor create(
-      MeasurementDescriptor.Name name, String description, MeasurementUnit unit) {
-    return new AutoValue_MeasurementDescriptor(name.asString(), description, unit);
+      String name, String description, MeasurementUnit unit) {
+    return create(Name.create(name), description, unit);
   }
 
   /**
    * Constructs a new {@link MeasurementDescriptor}.
    */
   public static MeasurementDescriptor create(
-      String name, String description, MeasurementUnit unit) {
-    return new AutoValue_MeasurementDescriptor(StringUtil.sanitize(name), description, unit);
+      Name name, String description, MeasurementUnit unit) {
+    return new AutoValue_MeasurementDescriptor(name, description, unit);
   }
 
   /**
    * Name of measurement, e.g. rpc_latency, cpu. Must be unique.
    */
-  // TODO(sebright): Change the type of this field to MeasurementDescriptor.Name.
-  public abstract String getName();
+  public abstract MeasurementDescriptor.Name getMeasurementDescriptorName();
+
+  /**
+   * Name of measurement, as a {@code String}.
+   */
+  public final String getName() {
+    return getMeasurementDescriptorName().asString();
+  }
 
   /**
    * Detailed description of the measurement, used in documentation.

--- a/core/src/main/java/com/google/instrumentation/stats/MeasurementMap.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MeasurementMap.java
@@ -103,9 +103,10 @@ public final class MeasurementMap implements Iterable<MeasurementValue> {
       // MeasurementMaps that we should see. We may want to go to a strategy of sort/eliminate
       // for larger MeasurementMaps.
       for (int i = 0; i < measurements.size(); i++) {
-        String current = measurements.get(i).getMeasurement().getName();
+        MeasurementDescriptor.Name current =
+            measurements.get(i).getMeasurement().getMeasurementDescriptorName();
         for (int j = i + 1; j < measurements.size(); j++) {
-          if (current.equals(measurements.get(j).getMeasurement().getName())) {
+          if (current.equals(measurements.get(j).getMeasurement().getMeasurementDescriptorName())) {
             measurements.remove(j);
             j--;
           }

--- a/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
@@ -62,6 +62,21 @@ public final class MeasurementDescriptorTest {
   }
 
   @Test
+  public void testMeasurementDescriptorNameSanitization() {
+    assertThat(MeasurementDescriptor.Name.create("md\1").asString())
+        .isEqualTo("md" + StringUtil.UNPRINTABLE_CHAR_SUBSTITUTE);
+  }
+
+  @Test
+  public void testMeasurementDescriptorNameEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            MeasurementDescriptor.Name.create("md1"), MeasurementDescriptor.Name.create("md1"))
+        .addEqualityGroup(MeasurementDescriptor.Name.create("md2"))
+        .testEquals();
+  }
+
+  @Test
   public void testMeasurementUnitEquals() {
     new EqualsTester()
         .addEqualityGroup(
@@ -86,7 +101,7 @@ public final class MeasurementDescriptorTest {
                 MeasurementUnit.create(
                     1, Arrays.asList(BasicUnit.BITS), Arrays.asList(BasicUnit.SECONDS))),
             MeasurementDescriptor.create(
-                "name",
+                MeasurementDescriptor.Name.create("name"),
                 "description",
                 MeasurementUnit.create(
                     1, Arrays.asList(BasicUnit.BITS), Arrays.asList(BasicUnit.SECONDS))))

--- a/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
@@ -53,6 +53,8 @@ public final class MeasurementDescriptorTest {
         MeasurementUnit.create(
             6, Arrays.asList(BasicUnit.BITS), Arrays.asList(BasicUnit.SECONDS)));
     assertThat(measurement.getName()).isEqualTo("Foo");
+    assertThat(measurement.getMeasurementDescriptorName())
+        .isEqualTo(MeasurementDescriptor.Name.create("Foo"));
     assertThat(measurement.getDescription()).isEqualTo("The description of Foo");
     assertThat(measurement.getUnit().getPower10()).isEqualTo(6);
     assertThat(measurement.getUnit().getNumerators()).hasSize(1);

--- a/core/src/test/java/com/google/instrumentation/stats/MeasurementMapTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MeasurementMapTest.java
@@ -110,8 +110,8 @@ public class MeasurementMapTest {
     while (e.hasNext() && a.hasNext()) {
       MeasurementValue expectedMeasurement = e.next();
       MeasurementValue actualMeasurement = a.next();
-      assertThat(expectedMeasurement.getMeasurement().getName())
-          .isEqualTo(actualMeasurement.getMeasurement().getName());
+      assertThat(expectedMeasurement.getMeasurement().getMeasurementDescriptorName())
+          .isEqualTo(actualMeasurement.getMeasurement().getMeasurementDescriptorName());
       assertThat(expectedMeasurement.getValue())
           .isWithin(0.00000001).of(actualMeasurement.getValue());
     }

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -43,8 +43,8 @@ public final class ViewDescriptorTest {
 
     assertThat(viewDescriptor.getName()).isEqualTo(name);
     assertThat(viewDescriptor.getDescription()).isEqualTo(description);
-    assertThat(viewDescriptor.getMeasurementDescriptor().getName())
-        .isEqualTo(measurementDescriptor.getName());
+    assertThat(viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName())
+        .isEqualTo(measurementDescriptor.getMeasurementDescriptorName());
     assertThat(viewDescriptor.getTagKeys()).hasSize(2);
     assertThat(viewDescriptor.getTagKeys().get(0).toString()).isEqualTo("foo");
     assertThat(viewDescriptor.getTagKeys().get(1).toString()).isEqualTo("bar");
@@ -70,8 +70,8 @@ public final class ViewDescriptorTest {
 
     assertThat(viewDescriptor.getName()).isEqualTo(name);
     assertThat(viewDescriptor.getDescription()).isEqualTo(description);
-    assertThat(viewDescriptor.getMeasurementDescriptor().getName())
-        .isEqualTo(measurementDescriptor.getName());
+    assertThat(viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName())
+        .isEqualTo(measurementDescriptor.getMeasurementDescriptorName());
     assertThat(viewDescriptor.getTagKeys()).hasSize(2);
     assertThat(viewDescriptor.getTagKeys().get(0).toString()).isEqualTo("foo");
     assertThat(viewDescriptor.getTagKeys().get(1).toString()).isEqualTo("bar");


### PR DESCRIPTION
We need to associate data with MeasurementDescriptors in several places in the
stats implementation.  For example, MeasurementMap maps MeasurementDescriptors
to recorded values.  Using MeasurementDescriptor as the key is not ideal,
because it is not obvious how the keys should be compared.  The keys could be
compared by name, since names are unique, or they could be compared by all
fields.

I think that we should always compare MeasurementDescriptors by name.  It is
more efficient, and it means that two MeasurementDescriptors with slightly
different descriptions won't be treated as distinct.  Having a separate key type
will make it clearer how the MeasurementDescriptors will be compared.

This commit just adds the class and doesn't change any existing APIs.