### PR TITLE
Roll back the change to have different factory methods for spans and spans with remote parent.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
@@ -19,14 +19,26 @@ import javax.annotation.Nullable;
 abstract class SpanFactory {
   /**
    * Creates and starts a new child {@link Span} (or root if parent is {@code null}), with parent
-   * being the {@code Span} designated by the {@link SpanContext} and the given options.
+   * being the designated {@code Span} and the given options.
    *
    * @param parent The parent of the returned {@code Span}.
-   * @param hasRemoteParent {@code true} if this is a child of a remote {@code Span}.
    * @param name The name of the returned {@code Span}.
    * @param options The options for the start of the {@code Span}.
    * @return A child {@code Span} that will have the name provided.
    */
-  abstract Span startSpan(
-      @Nullable SpanContext parent, boolean hasRemoteParent, String name, StartSpanOptions options);
+  abstract Span startSpan(@Nullable Span parent, String name, StartSpanOptions options);
+
+  /**
+   * Creates and starts a new child {@link Span} (or root if parent is {@code null}), with parent
+   * being the {@code Span} designated by the {@link SpanContext} and the given options.
+   *
+   * <p>This must be used to create a {@code Span} when the parent is on a different process.
+   *
+   * @param remoteParent The remote parent of the returned {@code Span}.
+   * @param name The name of the returned {@code Span}.
+   * @param options The options for the start of the {@code Span}.
+   * @return A child {@code Span} that will have the name provided.
+   */
+  abstract Span startSpanWithRemoteParent(
+      @Nullable SpanContext remoteParent, String name, StartSpanOptions options);
 }

--- a/core/src/main/java/com/google/instrumentation/trace/Tracer.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Tracer.java
@@ -207,11 +207,7 @@ public final class Tracer {
    * @throws NullPointerException if name is null.
    */
   public SpanBuilder spanBuilder(@Nullable Span parent, String name) {
-    return new SpanBuilder(
-        spanFactory,
-        parent == null ? null : parent.getContext(),
-        /* hasRemoteParent = */ false,
-        checkNotNull(name, "name"));
+    return SpanBuilder.builder(spanFactory, parent, checkNotNull(name, "name"));
   }
 
   /**
@@ -229,18 +225,20 @@ public final class Tracer {
    * @throws NullPointerException if name is null.
    */
   public SpanBuilder spanBuilderWithRemoteParent(@Nullable SpanContext remoteParent, String name) {
-    return new SpanBuilder(
-        spanFactory, remoteParent, /* hasRemoteParent = */ true, checkNotNull(name, "name"));
+    return SpanBuilder.builderWithRemoteParent(
+        spanFactory, remoteParent, checkNotNull(name, "name"));
   }
 
   // No-op implementation of the SpanFactory
   private static final class NoopSpanFactory extends SpanFactory {
     @Override
-    public Span startSpan(
-        @Nullable SpanContext parent,
-        boolean hasRemoteParent,
-        String name,
-        StartSpanOptions options) {
+    Span startSpan(@Nullable Span parent, String name, StartSpanOptions options) {
+      return BlankSpan.INSTANCE;
+    }
+
+    @Override
+    Span startSpanWithRemoteParent(
+        @Nullable SpanContext remoteParent, String name, StartSpanOptions options) {
       return BlankSpan.INSTANCE;
     }
   }

--- a/core/src/test/java/com/google/instrumentation/trace/BlankSpanTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/BlankSpanTest.java
@@ -38,10 +38,8 @@ public class BlankSpanTest {
     Map<String, AttributeValue> multipleAttributes = new HashMap<String, AttributeValue>();
     multipleAttributes.put(
         "MyStringAttributeKey", AttributeValue.stringAttributeValue("MyStringAttributeValue"));
-    multipleAttributes.put(
-        "MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
-    multipleAttributes.put(
-        "MyLongAttributeKey", AttributeValue.longAttributeValue(123));
+    multipleAttributes.put("MyBooleanAttributeKey", AttributeValue.booleanAttributeValue(true));
+    multipleAttributes.put("MyLongAttributeKey", AttributeValue.longAttributeValue(123));
     // Tests only that all the methods are not crashing/throwing errors.
     BlankSpan.INSTANCE.addAttributes(attributes);
     BlankSpan.INSTANCE.addAttributes(multipleAttributes);

--- a/core/src/test/java/com/google/instrumentation/trace/StartSpanOptionsTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/StartSpanOptionsTest.java
@@ -16,7 +16,6 @@ package com.google.instrumentation.trace;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import com.google.instrumentation.common.Timestamp;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;


### PR DESCRIPTION
Reason is that this way we can ensure an order between events recorded in different spans from the same trace.

We will calculate the timestamp using delay since the start time of the initial Span in the trace in the process (root span or a span with remote parent).