### PR TITLE
Start implementing StatsManagerImpl.record(...).

### DIFF
--- a/core_impl/src/main/java/com/google/instrumentation/common/DisruptorEventQueue.java
+++ b/core_impl/src/main/java/com/google/instrumentation/common/DisruptorEventQueue.java
@@ -79,7 +79,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * </pre>
  */
 @ThreadSafe
-public final class EventQueue {
+public final class DisruptorEventQueue {
   // An event in the {@link EventQueue}. Just holds a reference to an EventQueueEntry.
   private static final class InstrumentationEvent {
     private EventQueueEntry entry = null;
@@ -115,7 +115,7 @@ public final class EventQueue {
   }
 
   // The single instance of the class.
-  private static final EventQueue eventQueue = new EventQueue();
+  private static final DisruptorEventQueue eventQueue = new DisruptorEventQueue();
   // The event queue is built on this {@link Disruptor}.
   private final Disruptor<InstrumentationEvent> disruptor;
   // Ring Buffer for the {@link Disruptor} that underlies the queue.
@@ -124,7 +124,7 @@ public final class EventQueue {
   // Creates a new EventQueue. Private to prevent creation of non-singleton instance.
   // Suppress warnings for disruptor.handleEventsWith and Disruptor constructor
   @SuppressWarnings({"deprecation", "unchecked", "varargs"})
-  private EventQueue() {
+  private DisruptorEventQueue() {
     // Number of events that can be enqueued at any one time. If more than this are enqueued,
     // then subsequent attempts to enqueue new entries will block.
     // TODO(aveitch): consider making this a parameter to the constructor, so the queue can be
@@ -146,16 +146,16 @@ public final class EventQueue {
   }
 
   /**
-   * Returns the {@link EventQueue} instance.
+   * Returns the {@link DisruptorEventQueue} instance.
    *
    * @return the singleton {@code EventQueue} instance.
    */
-  public static EventQueue getInstance() {
+  public static DisruptorEventQueue getInstance() {
     return eventQueue;
   }
 
   /**
-   * Enqueues an event on the {@link EventQueue}.
+   * Enqueues an event on the {@link DisruptorEventQueue}.
    *
    * @param entry a class encapsulating the actions to be taken for event processing.
    */

--- a/core_impl/src/main/java/com/google/instrumentation/common/DisruptorEventQueue.java
+++ b/core_impl/src/main/java/com/google/instrumentation/common/DisruptorEventQueue.java
@@ -26,7 +26,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * A low-latency event queue for background updating of (possibly contended) objects. This is
  * intended for use by instrumentation methods to ensure that they do not block foreground
  * activities. To customize the action taken on reading the queue, derive a new class from {@link
- * EventQueueEntry} and pass it to the {@link #enqueue} method. The {@link EventQueueEntry#process}
+ * EventQueue.Entry} and pass it to the {@link #enqueue} method. The {@link Entry#process}
  * method of your class will be called and executed in a background thread. This class is a
  * Singleton.
  *
@@ -79,18 +79,18 @@ import javax.annotation.concurrent.ThreadSafe;
  * </pre>
  */
 @ThreadSafe
-public final class DisruptorEventQueue {
+public final class DisruptorEventQueue implements EventQueue {
   // An event in the {@link EventQueue}. Just holds a reference to an EventQueueEntry.
   private static final class InstrumentationEvent {
-    private EventQueueEntry entry = null;
+    private Entry entry = null;
 
     // Sets the EventQueueEntry associated with this InstrumentationEvent.
-    void setEntry(EventQueueEntry entry) {
+    void setEntry(Entry entry) {
       this.entry = entry;
     }
 
     // Returns the EventQueueEntry associated with this InstrumentationEvent.
-    EventQueueEntry getEntry() {
+    Entry getEntry() {
       return entry;
     }
   }
@@ -159,7 +159,8 @@ public final class DisruptorEventQueue {
    *
    * @param entry a class encapsulating the actions to be taken for event processing.
    */
-  public void enqueue(EventQueueEntry entry) {
+  @Override
+  public void enqueue(Entry entry) {
     long sequence = ringBuffer.next();
     try {
       InstrumentationEvent event = ringBuffer.get(sequence);

--- a/core_impl/src/main/java/com/google/instrumentation/common/EventQueue.java
+++ b/core_impl/src/main/java/com/google/instrumentation/common/EventQueue.java
@@ -14,13 +14,20 @@
 package com.google.instrumentation.common;
 
 /**
- * Base interface to be used for all entries in {@link DisruptorEventQueue}. For example usage, see
- * {@link DisruptorEventQueue}.
+ * A queue that processes events. See {@link DisruptorEventQueue} for an example.
  */
-public interface EventQueueEntry {
+public interface EventQueue {
+  void enqueue(Entry entry);
+
   /**
-   * Process the event associated with this entry. This will be called for every event in the
-   * associated {@link DisruptorEventQueue}.
+   * Base interface to be used for all entries in {@link EventQueue}. For example usage,
+   * see {@link DisruptorEventQueue}.
    */
-  void process();
+  public interface Entry {
+    /**
+     * Process the event associated with this entry. This will be called for every event in the
+     * associated {@link EventQueue}.
+     */
+    void process();
+  }
 }

--- a/core_impl/src/main/java/com/google/instrumentation/common/EventQueueEntry.java
+++ b/core_impl/src/main/java/com/google/instrumentation/common/EventQueueEntry.java
@@ -14,13 +14,13 @@
 package com.google.instrumentation.common;
 
 /**
- * Base interface to be used for all entries in {@link EventQueue}. For example usage, see {@link
- * EventQueue}.
+ * Base interface to be used for all entries in {@link DisruptorEventQueue}. For example usage, see
+ * {@link DisruptorEventQueue}.
  */
 public interface EventQueueEntry {
   /**
    * Process the event associated with this entry. This will be called for every event in the
-   * associated {@link EventQueue}.
+   * associated {@link DisruptorEventQueue}.
    */
   void process();
 }

--- a/core_impl/src/main/java/com/google/instrumentation/common/SimpleEventQueue.java
+++ b/core_impl/src/main/java/com/google/instrumentation/common/SimpleEventQueue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.common;
+
+/**
+ * An {@link EventQueue} that processes events in the current thread. This class can be used for
+ * testing.
+ */
+public class SimpleEventQueue implements EventQueue {
+
+  @Override
+  public void enqueue(Entry entry) {
+    entry.process();
+  }
+}

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -17,6 +17,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * A class that stores a singleton map from {@link MeasurementDescriptor.Name} to {@link View}.
@@ -51,5 +52,24 @@ final class MeasurementDescriptorToViewMap {
    */
   void putView(MeasurementDescriptor.Name name, View view) {
     mutableMap.put(name, view);
+  }
+
+  // Records stats with a set of tags.
+  void record(Map<String, String> tags, MeasurementMap stats) {
+    for (MeasurementValue mv : stats) {
+      if (mv.getMeasurement()
+          .getMeasurementDescriptorName()
+          .equals(SupportedViews.SUPPORTED_MEASUREMENT_DESCRIPTOR.getMeasurementDescriptorName())) {
+        recordSupportedMeasurement(tags, mv.getValue());
+      }
+    }
+  }
+
+  private void recordSupportedMeasurement(Map<String, String> tags, double value) {
+    //  // TODO(sebright): Record the value in the view.
+    //
+    //  synchronized (mutableMap) {
+    //    View view = getView(SupportedViews.SUPPORTED_VIEW);
+    //  }
   }
 }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
@@ -15,15 +15,17 @@ package com.google.instrumentation.stats;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Native Implementation of {@link StatsContext}.
  */
 final class StatsContextImpl extends StatsContext {
-  final HashMap<String, String> tags;
+  final Map<String, String> tags;
 
-  StatsContextImpl(HashMap<String, String> tags) {
+  StatsContextImpl(Map<String, String> tags) {
     this.tags = tags;
   }
 
@@ -65,7 +67,7 @@ final class StatsContextImpl extends StatsContext {
   private static final class Builder extends StatsContext.Builder {
     private final HashMap<String, String> tags;
 
-    private Builder(HashMap<String, String> tags) {
+    private Builder(Map<String, String> tags) {
       this.tags = new HashMap<String, String>(tags);
     }
 
@@ -77,7 +79,7 @@ final class StatsContextImpl extends StatsContext {
 
     @Override
     public StatsContext build() {
-      return new StatsContextImpl(new HashMap<String, String>(tags));
+      return new StatsContextImpl(Collections.unmodifiableMap(new HashMap<String, String>(tags)));
     }
   }
 }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -89,25 +89,27 @@ public final class StatsManagerImpl extends StatsManager {
    * @param measurementValues the measurements to record
    */
   void record(StatsContextImpl tags, MeasurementMap measurementValues) {
-    queue.enqueue(new StatsEvent(measurementDescriptorToViewMap, tags.tags, measurementValues));
+    queue.enqueue(new StatsEvent(this, tags.tags, measurementValues));
   }
 
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).
   private static final class StatsEvent implements EventQueue.Entry {
     private final Map<String, String> tags;
     private final MeasurementMap stats;
-    private final MeasurementDescriptorToViewMap statsMap;
+    private final StatsManagerImpl statsManager;
 
     StatsEvent(
-        MeasurementDescriptorToViewMap statsMap, Map<String, String> tags, MeasurementMap stats) {
-      this.statsMap = statsMap;
+        StatsManagerImpl statsManager, Map<String, String> tags, MeasurementMap stats) {
+      this.statsManager = statsManager;
       this.tags = tags;
       this.stats = stats;
     }
 
     @Override
     public void process() {
-      statsMap.record(tags, stats);
+      statsManager
+          .measurementDescriptorToViewMap
+          .record(tags, stats);
     }
   }
 

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -35,9 +35,10 @@ public final class StatsManagerImpl extends StatsManager {
     // and view RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW for this prototype.
     // The prototype does not allow setting measurement descriptor entries dynamically for now.
     // TODO(songya): remove the logic for checking the preset descriptor.
-    if (!viewDescriptor.equals(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW)) {
+    if (!viewDescriptor.equals(SupportedViews.SUPPORTED_VIEW)) {
       throw new UnsupportedOperationException(
-          "The prototype will only support Distribution View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW.");
+          "The prototype will only support Distribution View "
+              + SupportedViews.SUPPORTED_VIEW.getName());
     }
 
     if (measurementDescriptorToViewMap.getView(viewDescriptor) != null) {

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -13,6 +13,7 @@
 
 package com.google.instrumentation.stats;
 
+import com.google.instrumentation.common.EventQueue;
 import com.google.instrumentation.common.Function;
 import com.google.instrumentation.common.Timestamp;
 import com.google.instrumentation.stats.View.DistributionView;
@@ -24,6 +25,16 @@ import com.google.instrumentation.stats.ViewDescriptor.IntervalViewDescriptor;
  * Native Implementation of {@link StatsManager}.
  */
 public final class StatsManagerImpl extends StatsManager {
+  @SuppressWarnings("unused")
+  private final EventQueue queue;
+
+  public StatsManagerImpl() {
+    queue = EventQueue.getInstance();
+  }
+
+  StatsManagerImpl(EventQueue queue) {
+    this.queue = queue;
+  }
 
   private final MeasurementDescriptorToViewMap measurementDescriptorToViewMap =
       new MeasurementDescriptorToViewMap();

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -13,7 +13,7 @@
 
 package com.google.instrumentation.stats;
 
-import com.google.instrumentation.common.EventQueue;
+import com.google.instrumentation.common.DisruptorEventQueue;
 import com.google.instrumentation.common.EventQueueEntry;
 import com.google.instrumentation.common.Function;
 import com.google.instrumentation.common.Timestamp;
@@ -27,13 +27,13 @@ import java.util.Map;
  * Native Implementation of {@link StatsManager}.
  */
 public final class StatsManagerImpl extends StatsManager {
-  private final EventQueue queue;
+  private final DisruptorEventQueue queue;
 
   public StatsManagerImpl() {
-    queue = EventQueue.getInstance();
+    queue = DisruptorEventQueue.getInstance();
   }
 
-  StatsManagerImpl(EventQueue queue) {
+  StatsManagerImpl(DisruptorEventQueue queue) {
     this.queue = queue;
   }
 

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.instrumentation.common.DisruptorEventQueue;
-import com.google.instrumentation.common.EventQueueEntry;
+import com.google.instrumentation.common.EventQueue;
 import com.google.instrumentation.common.Function;
 import com.google.instrumentation.common.Timestamp;
 import com.google.instrumentation.stats.View.DistributionView;
@@ -27,13 +27,13 @@ import java.util.Map;
  * Native Implementation of {@link StatsManager}.
  */
 public final class StatsManagerImpl extends StatsManager {
-  private final DisruptorEventQueue queue;
+  private final EventQueue queue;
 
   public StatsManagerImpl() {
     queue = DisruptorEventQueue.getInstance();
   }
 
-  StatsManagerImpl(DisruptorEventQueue queue) {
+  StatsManagerImpl(EventQueue queue) {
     this.queue = queue;
   }
 
@@ -93,7 +93,7 @@ public final class StatsManagerImpl extends StatsManager {
   }
 
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).
-  private static final class StatsEvent implements EventQueueEntry {
+  private static final class StatsEvent implements EventQueue.Entry {
     private final Map<String, String> tags;
     private final MeasurementMap stats;
     private final MeasurementDescriptorToViewMap statsMap;

--- a/core_impl/src/main/java/com/google/instrumentation/stats/SupportedViews.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/SupportedViews.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+/**
+ * Constants specifying the view that is supported in the initial stats implementation.
+ */
+class SupportedViews {
+  static final ViewDescriptor SUPPORTED_VIEW = RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW;
+  static final MeasurementDescriptor SUPPORTED_MEASUREMENT_DESCRIPTOR =
+      RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY;
+
+  private SupportedViews() {}
+}

--- a/core_impl/src/test/java/com/google/instrumentation/common/DisruptorEventQueueTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/common/DisruptorEventQueueTest.java
@@ -54,7 +54,7 @@ public class DisruptorEventQueueTest {
   }
 
   // EventQueueEntry for incrementing a Counter.
-  private static class IncrementEvent implements EventQueueEntry {
+  private static class IncrementEvent implements EventQueue.Entry {
     private final Counter counter;
 
     IncrementEvent(Counter counter) {

--- a/core_impl/src/test/java/com/google/instrumentation/common/DisruptorEventQueueTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/common/DisruptorEventQueueTest.java
@@ -19,9 +19,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link EventQueue}. */
+/** Unit tests for {@link DisruptorEventQueue}. */
 @RunWith(JUnit4.class)
-public class EventQueueTest {
+public class DisruptorEventQueueTest {
   // Simple class to use that keeps an incrementing counter. Will fail with an assertion if
   // increment is used from multiple threads, or if the stored value is different from that expected
   // by the caller.
@@ -71,7 +71,7 @@ public class EventQueueTest {
   public void incrementOnce() {
     Counter counter = new Counter();
     IncrementEvent ie = new IncrementEvent(counter);
-    EventQueue.getInstance().enqueue(ie);
+    DisruptorEventQueue.getInstance().enqueue(ie);
     // Sleep briefly, to allow background operations to complete.
     try {
       Thread.sleep(500);
@@ -87,7 +87,7 @@ public class EventQueueTest {
     Counter counter = new Counter();
     for (int i = 0; i < tenK; i++) {
       IncrementEvent ie = new IncrementEvent(counter);
-      EventQueue.getInstance().enqueue(ie);
+      DisruptorEventQueue.getInstance().enqueue(ie);
     }
     // Sleep briefly, to allow background operations to complete.
     try {

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
@@ -62,4 +62,13 @@ public class StatsManagerImplTest {
     thrown.expect(IllegalArgumentException.class);
     statsManager.getView(RpcConstants.RPC_CLIENT_REQUEST_COUNT_VIEW);
   }
+
+  // TODO(sebright): Turn this into a real test once StatsManagerImpl.record(...) is implemented.
+  // It currently only shows that record(...) can be called with a SimpleEventQueue.
+  @Test
+  public void testRecord() {
+    statsManager.record(
+        StatsContextFactoryImpl.DEFAULT,
+        MeasurementMap.of(RpcConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 10));
+  }
 }

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
@@ -15,6 +15,7 @@ package com.google.instrumentation.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.instrumentation.common.SimpleEventQueue;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -30,7 +31,7 @@ public class StatsManagerImplTest {
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
-  private final StatsManager statsManager = new StatsManagerImpl();
+  private final StatsManagerImpl statsManager = new StatsManagerImpl(new SimpleEventQueue());
 
   @Test
   public void testRegisterAndGetView() throws Exception {


### PR DESCRIPTION
Changes in this PR:
- Store `StatsContextImpl`'s map of tags in an unmodifiable map so that it is safe to access from other classes.
- Add a field for an event queue to `StatsManagerImpl`.
- Create an `EventQueue` interface to allow testing with a simple `EventQueue`.  I renamed the original `EventQueue` class to `DisruptorEventQueue`.
- Add a `StatsEvent` class that can be added to the `EventQueue`.
- Add a record method to `StatsManagerImpl`.  It doesn't do anything yet.

It is much easier to review the individual commits, because git didn't follow the rename of `EventQueue`.

/cc @a-veitch @dinooliva @bogdandrutu