### PR TITLE
Update serialize and deserialize to use byte[] instead of byte stream.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
@@ -14,7 +14,6 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
-import java.io.OutputStream;
 
 /**
  * An immutable context for stats operations.
@@ -52,12 +51,12 @@ public abstract class StatsContext {
   /**
    * Serializes the {@link StatsContext} into the on-the-wire representation.
    *
-   * <p>The inverse of {@link StatsContextFactory#deserialize(java.io.InputStream)} and should be
-   * based on the {@link StatsContext} protobuf representation.
+   * <p>The inverse of {@link StatsContextFactory#deserialize(byte[])} and should be
+   * based on the {@link StatsContext} binary representation.
    *
-   * @param output the {@link OutputStream} to add the serialized form of this {@link StatsContext}.
+   * @return a byte array that represents the serialized form of this {@link StatsContext}.
    */
-  public abstract void serialize(OutputStream output) throws IOException;
+  public abstract byte[] serialize() throws IOException;
 
   /**
    * Builder for {@link StatsContext}.

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * An immutable context for stats operations.
@@ -57,6 +58,12 @@ public abstract class StatsContext {
    * @return a byte array that represents the serialized form of this {@link StatsContext}.
    */
   public abstract byte[] serialize() throws IOException;
+
+  /**
+   * Old version of {@link StatsContext} serialization.
+   */
+  @Deprecated
+  public abstract void serialize(OutputStream output) throws IOException;
 
   /**
    * Builder for {@link StatsContext}.

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.text.ParseException;
 
 /**
  * Factory class for {@link StatsContext}.
@@ -23,13 +23,13 @@ public abstract class StatsContextFactory {
   /**
    * Creates a {@link StatsContext} from the given on-the-wire encoded representation.
    *
-   * <p>Should be the inverse of {@link StatsContext#serialize(java.io.OutputStream)}. The
+   * <p>Should be the inverse of {@link StatsContext#serialize()}. The
    * serialized representation should be based on the {@link StatsContext} binary representation.
    *
    * @param input on-the-wire representation of a {@link StatsContext}
    * @return a {@link StatsContext} deserialized from {@code input}
    */
-  public abstract StatsContext deserialize(InputStream input) throws IOException;
+  public abstract StatsContext deserialize(byte[] input) throws IOException, ParseException;
 
   /**
    * Returns the default {@link StatsContext}.

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 
 /**
@@ -30,6 +31,12 @@ public abstract class StatsContextFactory {
    * @return a {@link StatsContext} deserialized from {@code input}
    */
   public abstract StatsContext deserialize(byte[] input) throws IOException, ParseException;
+
+  /**
+   * Old version of {@link StatsContext} deserialization.
+   */
+  @Deprecated
+  public abstract StatsContext deserialize(InputStream input) throws IOException;
 
   /**
    * Returns the default {@link StatsContext}.

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
@@ -13,7 +13,9 @@
 
 package com.google.instrumentation.stats;
 
+import com.google.common.io.ByteStreams;
 import java.io.IOException;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.util.HashMap;
 
@@ -31,6 +33,16 @@ final class StatsContextFactoryImpl extends StatsContextFactory {
   @Override
   public StatsContextImpl deserialize(byte[] input) throws IOException, ParseException {
     return StatsSerializer.deserialize(input);
+  }
+
+  @Deprecated
+  @Override
+  public StatsContext deserialize(InputStream input) throws IOException {
+    try {
+      return this.deserialize(ByteStreams.toByteArray(input));
+    } catch (ParseException e) {
+      throw new IOException(e);
+    }
   }
 
   @Override

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.text.ParseException;
 import java.util.HashMap;
 
 /**
@@ -29,7 +29,7 @@ final class StatsContextFactoryImpl extends StatsContextFactory {
    * <p>The encoded tags are of the form: {@code <version_id><encoded_tags>}
    */
   @Override
-  public StatsContextImpl deserialize(InputStream input) throws IOException {
+  public StatsContextImpl deserialize(byte[] input) throws IOException, ParseException {
     return StatsSerializer.deserialize(input);
   }
 

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
@@ -14,13 +14,13 @@
 package com.google.instrumentation.stats;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 
 /**
  * Native Implementation of {@link StatsContext}.
  */
 final class StatsContextImpl extends StatsContext {
+
   final HashMap<String, String> tags;
 
   StatsContextImpl(HashMap<String, String> tags) {
@@ -38,13 +38,15 @@ final class StatsContextImpl extends StatsContext {
   }
 
   /**
-   * Serializes a {@link StatsContextImpl} into {@code CensusContextProto} serialized format.
+   * Serializes a {@link StatsContextImpl} into on-the-wire serialized format.
    *
    * <p>The encoded tags are of the form: {@code <version_id><encoded_tags>}
+   *
+   * @return a byte array that represents the serialized StatsContext.
    */
   @Override
-  public void serialize(OutputStream output) throws IOException {
-    StatsSerializer.serialize(this, output);
+  public byte[] serialize() throws IOException {
+    return StatsSerializer.serialize(this);
   }
 
   @Override
@@ -63,6 +65,7 @@ final class StatsContextImpl extends StatsContext {
   }
 
   private static final class Builder extends StatsContext.Builder {
+
     private final HashMap<String, String> tags;
 
     private Builder(HashMap<String, String> tags) {

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
@@ -13,7 +13,9 @@
 
 package com.google.instrumentation.stats;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.HashMap;
 
 /**
@@ -47,6 +49,14 @@ final class StatsContextImpl extends StatsContext {
   @Override
   public byte[] serialize() throws IOException {
     return StatsSerializer.serialize(this);
+  }
+
+  @Deprecated
+  @Override
+  public void serialize(OutputStream output) throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    byteArrayOutputStream.write(this.serialize());
+    byteArrayOutputStream.writeTo(output);
   }
 
   @Override

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.testing.EqualsTester;
 
 import com.google.io.base.VarInt;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.junit.Test;
@@ -161,27 +160,21 @@ public class StatsContextTest {
   }
 
   private static void testSerialize(Tag... tags) throws IOException {
-    ByteArrayOutputStream actual = new ByteArrayOutputStream();
-    ByteArrayOutputStream expected = new ByteArrayOutputStream();
-    expected.write(VERSION_ID);
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    byteArrayOutputStream.write(VERSION_ID);
     StatsContext.Builder builder = DEFAULT.builder();
     for (Tag tag : tags) {
       builder.set(tag.getKey(), tag.getValue());
-      expected.write(VALUE_TYPE_STRING);
-      encodeString(tag.getKey().toString(), expected);
-      encodeString(tag.getValue().toString(), expected);
+      byteArrayOutputStream.write(VALUE_TYPE_STRING);
+      encodeString(tag.getKey().toString(), byteArrayOutputStream);
+      encodeString(tag.getValue().toString(), byteArrayOutputStream);
     }
-    builder.build().serialize(actual);
-
-    assertThat(actual.toByteArray()).isEqualTo(expected.toByteArray());
+    assertThat(builder.build().serialize()).isEqualTo(byteArrayOutputStream.toByteArray());
   }
 
   private static void testRoundtripSerialization(StatsContext expected) throws Exception {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    expected.serialize(output);
-    ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
-    StatsContext actual = Stats.getStatsContextFactory().deserialize(input);
-    assertThat(actual).isEqualTo(expected);
+    assertThat(Stats.getStatsContextFactory().deserialize(expected.serialize()))
+        .isEqualTo(expected);
   }
 
   private static final void encodeString(String input, ByteArrayOutputStream byteArrayOutputStream)


### PR DESCRIPTION
Related issue: https://github.com/google/instrumentation-java/issues/213
This PR is built upon PR https://github.com/google/instrumentation-java/pull/208.

Also need to update any external code that calls serialize() and deserialize(), since the signature of these methods now changes.