### PR TITLE
Start adding a "tag" package.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/internal/StringUtil.java
+++ b/core/src/main/java/com/google/instrumentation/internal/StringUtil.java
@@ -11,17 +11,25 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.stats;
+package com.google.instrumentation.internal;
 
 /**
- * Utility methods for working with tag keys, tag values, and metric names.
+ * Internal utility methods for working with tag keys, tag values, and metric names.
  */
-final class StringUtil {
+public final class StringUtil {
 
-  static final int MAX_LENGTH = 255;
-  static final char UNPRINTABLE_CHAR_SUBSTITUTE = '_';
+  public static final int MAX_LENGTH = 255;
+  public static final char UNPRINTABLE_CHAR_SUBSTITUTE = '_';
 
-  static String sanitize(String str) {
+  /**
+   * Replaces non-printable characters with underscores and truncates to {@link
+   * StringUtil#MAX_LENGTH}.
+   *
+   * @param str the {@code String} to be sanitized.
+   * @return the {@code String} with all non-printable characters replaced by underscores, truncated
+   *     to {@code MAX_LENGTH}.
+   */
+  public static String sanitize(String str) {
     if (str.length() > MAX_LENGTH) {
       str = str.substring(0, MAX_LENGTH);
     }

--- a/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
-
+import com.google.instrumentation.internal.StringUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/com/google/instrumentation/stats/TagKey.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagKey.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
 
 /**
  * Tag keys.

--- a/core/src/main/java/com/google/instrumentation/stats/TagValue.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagValue.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
 
 /**
  * Tag values.

--- a/core/src/main/java/com/google/instrumentation/tag/TagKey.java
+++ b/core/src/main/java/com/google/instrumentation/tag/TagKey.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
+import javax.annotation.concurrent.Immutable;
+
+
+/**
+ * Tag keys.
+ *
+ * <p>{@code TagKey}s are {@code String}s with enforced restrictions.
+ */
+@Immutable
+@AutoValue
+public abstract class TagKey {
+  public static final int MAX_LENGTH = StringUtil.MAX_LENGTH;
+
+  TagKey() {}
+
+  /**
+   * Constructs a {@link TagKey} from the given string. The string will be sanitized such that:
+   *
+   * <ol>
+   *   <li>length is restricted to {@link StringUtil#MAX_LENGTH}, strings longer than that will be
+   *       truncated.
+   *   <li>characters are restricted to printable ascii characters, non-printable characters will be
+   *       replaced by an underscore '_'.
+   * </ol>
+   */
+  public static TagKey create(String key) {
+    return new AutoValue_TagKey(StringUtil.sanitize(key));
+  }
+
+  public abstract String asString();
+}

--- a/core/src/main/java/com/google/instrumentation/tag/TagSet.java
+++ b/core/src/main/java/com/google/instrumentation/tag/TagSet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import com.google.auto.value.AutoValue;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.concurrent.Immutable;
+
+
+/** A set of tags. */
+@Immutable
+@AutoValue
+public abstract class TagSet {
+  /** The empty {@code TagSet}. */
+  public static final TagSet EMPTY = builder().build();
+
+  TagSet() {}
+
+  static TagSet create(HashMap<TagKey, TagValue> tags) {
+    return new AutoValue_TagSet(tags);
+  }
+
+  abstract Map<TagKey, TagValue> getTags();
+
+  /** Returns an empty builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns a builder with the same contents as the given {@code TagSet}.
+   *
+   * @param initialTags the initial tags.
+   * @return a builder containing the initial tags.
+   */
+  public static Builder builder(TagSet initialTags) {
+    return new Builder(initialTags.getTags());
+  }
+
+  /** Shorthand for {@code builder(tagSet).set(k1, v1).build()}. */
+  public final TagSet with(TagKey k1, TagValue v1) {
+    return builder(this).add(k1, v1).build();
+  }
+
+  /** Shorthand for {@code builder(tagSet).set(k1, v1).set(k2, v2).build()}. */
+  public final TagSet with(TagKey k1, TagValue v1, TagKey k2, TagValue v2) {
+    return builder(this).add(k1, v1).add(k2, v2).build();
+  }
+
+  /** Shorthand for {@code builder(tagSet).set(k1, v1).set(k2, v2).set(k3, v3).build()}. */
+  public final TagSet with(TagKey k1, TagValue v1, TagKey k2, TagValue v2, TagKey k3, TagValue v3) {
+    return builder(this).add(k1, v1).add(k2, v2).add(k3, v3).build();
+  }
+
+  /** Builder for {@link TagSet}. */
+  public static final class Builder {
+    private final Map<TagKey, TagValue> tags;
+
+    private Builder() {
+      this.tags = new HashMap<TagKey, TagValue>();
+    }
+
+    private Builder(Map<TagKey, TagValue> tags) {
+      this.tags = new HashMap<TagKey, TagValue>(tags);
+    }
+
+    /**
+     * Associates the given tag key with the given tag value.
+     *
+     * @param key the key
+     * @param value the value to be associated with {@code key}
+     * @return {@code this}
+     */
+    public Builder add(TagKey key, TagValue value) {
+      tags.put(key, value);
+      return this;
+    }
+
+    /** Builds a {@link TagSet} from the specified keys and values. */
+    public TagSet build() {
+      return TagSet.create(new HashMap<TagKey, TagValue>(tags));
+    }
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/tag/TagValue.java
+++ b/core/src/main/java/com/google/instrumentation/tag/TagValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
+import javax.annotation.concurrent.Immutable;
+
+
+/**
+ * Tag values.
+ *
+ * <p>{@code TagValue}s are {@code String}s with enforced restrictions.
+ */
+@Immutable
+@AutoValue
+public abstract class TagValue {
+  public static final int MAX_LENGTH = StringUtil.MAX_LENGTH;
+
+  TagValue() {}
+
+  /**
+   * Constructs a {@link TagValue} from the given string. The string will be sanitized such that:
+   *
+   * <ol>
+   *   <li>length is restricted to {@link StringUtil#MAX_LENGTH}, strings longer than that will be
+   *       truncated.
+   *   <li>characters are restricted to printable ascii characters, non-printable characters will be
+   *       replaced by an underscore '_'.
+   * </ol>
+   */
+  public static TagValue create(String value) {
+    return new AutoValue_TagValue(StringUtil.sanitize(value));
+  }
+
+  public abstract String asString();
+}

--- a/core/src/test/java/com/google/instrumentation/internal/StringUtilTest.java
+++ b/core/src/test/java/com/google/instrumentation/internal/StringUtilTest.java
@@ -11,10 +11,11 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.stats;
+package com.google.instrumentation.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import com.google.instrumentation.stats.MeasurementDescriptor.BasicUnit;
 import com.google.instrumentation.stats.MeasurementDescriptor.MeasurementUnit;
 import java.util.Arrays;

--- a/core/src/test/java/com/google/instrumentation/stats/TagKeyTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/TagKeyTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/instrumentation/stats/TagValueTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/TagValueTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/instrumentation/tag/TagKeyTest.java
+++ b/core/src/test/java/com/google/instrumentation/tag/TagKeyTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TagKey}
+ */
+@RunWith(JUnit4.class)
+public final class TagKeyTest {
+  @Test
+  public void testKeyMaxLength() {
+    char[] key = new char[TagKey.MAX_LENGTH];
+    char[] truncKey = new char[TagKey.MAX_LENGTH + 10];
+    Arrays.fill(key, 'k');
+    Arrays.fill(truncKey, 'k');
+    assertThat(TagKey.create(new String(truncKey)).asString()).isEqualTo(new String(key));
+  }
+
+  @Test
+  public void testKeyBadChar() {
+    String key = "\2ab\3cd";
+    assertThat(TagKey.create(key).asString())
+        .isEqualTo(StringUtil.UNPRINTABLE_CHAR_SUBSTITUTE + "ab"
+                 + StringUtil.UNPRINTABLE_CHAR_SUBSTITUTE + "cd");
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TagKey.create("foo"), TagKey.create("foo"))
+        .addEqualityGroup(TagKey.create("bar"))
+        .testEquals();
+  }
+
+  @Test
+  public void testAsString() {
+    assertThat(TagKey.create("foo").asString()).isEqualTo("foo");
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/tag/TagSetTest.java
+++ b/core/src/test/java/com/google/instrumentation/tag/TagSetTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TagSet}.
+ */
+@RunWith(JUnit4.class)
+public class TagSetTest {
+
+  private static final TagKey K1 = TagKey.create("k1");
+  private static final TagKey K2 = TagKey.create("k2");
+  private static final TagKey K3 = TagKey.create("k3");
+  private static final TagKey K10 = TagKey.create("k10");
+
+  private static final TagValue V1 = TagValue.create("v1");
+  private static final TagValue V2 = TagValue.create("v2");
+  private static final TagValue V3 = TagValue.create("v3");
+  private static final TagValue V10 = TagValue.create("v10");
+
+  @Test
+  public void testEmpty() {
+    assertThat(TagSet.EMPTY.getTags()).isEmpty();
+  }
+
+  @Test
+  public void testBuilder() {
+    assertThat(TagSet.builder().build().getTags()).isEmpty();
+    assertThat(TagSet.builder().add(K1, V1).build().getTags())
+        .containsExactly(K1, V1);
+    assertThat(TagSet.builder().add(K1, V1).add(K2, V2).build().getTags())
+        .containsExactly(K1, V1, K2, V2);
+  }
+
+  @Test
+  public void overrideEarlierKey() {
+    assertThat(TagSet.builder().add(K1, V1).add(K1, V2).build().getTags())
+        .containsExactly(K1, V2);
+  }
+
+  @Test
+  public void reuseBuilder() {
+    TagSet.Builder builder = TagSet.builder();
+    builder.add(K1, V1);
+    TagSet tags1 = builder.build();
+    builder.add(K1, V2);
+    TagSet tags2 = builder.build();
+    assertThat(tags1.getTags()).containsExactly(K1, V1);
+    assertThat(tags2.getTags()).containsExactly(K1, V2);
+  }
+
+  @Test
+  public void testWithMethods() {
+    assertThat(TagSet.EMPTY.with(K1, V1))
+        .isEqualTo(TagSet.builder().add(K1, V1).build());
+    assertThat(TagSet.EMPTY.with(K1, V1, K2, V2))
+        .isEqualTo(TagSet.builder().add(K1, V1).add(K2, V2).build());
+    assertThat(TagSet.EMPTY.with(K1, V1, K2, V2, K3, V3))
+        .isEqualTo(TagSet.builder().add(K1, V1).add(K2, V2).add(K3, V3).build());
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TagSet.EMPTY, TagSet.EMPTY)
+        .addEqualityGroup(
+            TagSet.EMPTY.with(K1, V1),
+            TagSet.EMPTY.with(K1, V1),
+            TagSet.EMPTY.with(K1, V1, K1, V1))
+        .addEqualityGroup(
+            TagSet.EMPTY.with(K1, V1, K2, V2),
+            TagSet.EMPTY.with(K1, V1, K2, V2),
+            TagSet.EMPTY.with(K2, V2, K1, V1))
+        .addEqualityGroup(TagSet.EMPTY.with(K10, V1))
+        .addEqualityGroup(TagSet.EMPTY.with(K1, V10))
+        .testEquals();
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/tag/TagValueTest.java
+++ b/core/src/test/java/com/google/instrumentation/tag/TagValueTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.tag;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TagValue}
+ */
+@RunWith(JUnit4.class)
+public final class TagValueTest {
+  @Test
+  public void testValueMaxLength() {
+    char[] value = new char[TagValue.MAX_LENGTH];
+    char[] truncValue = new char[TagValue.MAX_LENGTH + 10];
+    Arrays.fill(value, 'v');
+    Arrays.fill(truncValue, 'v');
+    assertThat(TagValue.create(new String(truncValue)).asString()).isEqualTo(new String(value));
+  }
+
+  @Test
+  public void testValueBadChar() {
+    String value = "\2ab\3cd";
+    assertThat(TagValue.create(value).asString())
+        .isEqualTo(StringUtil.UNPRINTABLE_CHAR_SUBSTITUTE + "ab"
+                 + StringUtil.UNPRINTABLE_CHAR_SUBSTITUTE + "cd");
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(TagValue.create("foo"), TagValue.create("foo"))
+        .addEqualityGroup(TagValue.create("bar"))
+        .testEquals();
+  }
+
+  @Test
+  public void testAsString() {
+    assertThat(TagValue.create("foo").asString()).isEqualTo("foo");
+  }
+}


### PR DESCRIPTION
This PR starts adding tagging as a separate feature.  There are two commits:


#### Move StringUtil to an "internal" package.
This will allow the class to be used by multiple packages.

#### Start adding a "tag" package.
This commit adds TagKey, TagValue, and TagSet to the new package. It does not
modify any classes in "stats", for backwards compatibility.  TagKey and TagValue
are the same as the corresponding classes in "stats", except that they use the
toString() methods generated by AutoValue.  TagSet is like StatsContext, except
that it uses AutoValue and doesn't contain any methods for recording stats or
serializing/deserializing.

/cc @songy23 @dinooliva @a-veitch 