### PR TITLE
Enable Error Prone experimental suggestions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
       cat gradle/errorprone/warnings > $HOME/.gradle/gradle.properties ;
       cat gradle/errorprone/experimental_errors >> $HOME/.gradle/gradle.properties ;
       cat gradle/errorprone/experimental_warnings  >> $HOME/.gradle/gradle.properties ;
+      cat gradle/errorprone/experimental_suggestions  >> $HOME/.gradle/gradle.properties ;
     fi
 
 # Skip Travis' default Gradle install step. See http://stackoverflow.com/a/26575080.

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,11 @@ subprojects {
                     it as String
                 }
             }
+            if (rootProject.hasProperty("errorProneExperimentalSuggestions")) {
+                it.options.compilerArgs += rootProject.properties["errorProneExperimentalSuggestions"].split(',').collect {
+                    it as String
+                }
+            }
         }
         it.options.encoding = "UTF-8"
         // TODO(bdrutu): Enable when fix the issue with configuring bootstrap class.

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -65,6 +65,7 @@ final class MeasurementDescriptorToViewMap {
     }
   }
 
+  @SuppressWarnings("MethodCanBeStatic")
   private void recordSupportedMeasurement(Map<String, String> tags, double value) {
     //  // TODO(sebright): Record the value in the view.
     //

--- a/gradle/errorprone/experimental_suggestions
+++ b/gradle/errorprone/experimental_suggestions
@@ -1,0 +1,15 @@
+errorProneExperimentalSuggestions = \
+-Xep:ConstantField:ERROR,\
+-Xep:EmptySetMultibindingContributions:ERROR,\
+-Xep:MethodCanBeStatic:ERROR,\
+-Xep:MixedArrayDimensions:ERROR,\
+-Xep:MultiVariableDeclaration:ERROR,\
+-Xep:MultipleTopLevelClasses:ERROR,\
+-Xep:PackageLocation:ERROR,\
+-Xep:PrivateConstructorForNoninstantiableModuleTest:ERROR,\
+-Xep:PrivateConstructorForUtilityClass:OFF,\
+-Xep:RemoveUnusedImports:ERROR,\
+-Xep:ThrowsUncheckedException:ERROR,\
+-Xep:UnnecessaryStaticImport:ERROR,\
+-Xep:UseBinds:ERROR,\
+-Xep:WildcardImport:ERROR


### PR DESCRIPTION
This includes RemoveUnusedImports. I excluded PrivateConstructorForUtilityClass
because there were too many warnings in the examples directory.