### PR TITLE
Move Gradle build from "install" to "script" section of .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ before_install:
       cat gradle/errorprone/experimental_warnings  >> $HOME/.gradle/gradle.properties ;
     fi
 
+# Skip Travis' default Gradle install step. See http://stackoverflow.com/a/26575080.
+install: true
+
 script:
   - case "$TASK" in
       "CHECK_GIT_HISTORY")

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,12 @@ before_install:
       cat gradle/errorprone/experimental_warnings  >> $HOME/.gradle/gradle.properties ;
     fi
 
-install:
-  - if \[ "$TASK" == "BUILD" \]; then
-      ./gradlew clean assemble --stacktrace ;
-    fi
-
 script:
   - case "$TASK" in
       "CHECK_GIT_HISTORY")
         python check-git-history.py ;;
       "BUILD")
+        ./gradlew clean assemble --stacktrace ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")
             ./gradlew check :instrumentation-java-all:jacocoTestReport ;;


### PR DESCRIPTION
The Gradle build command is the command that should determine whether the build
succeeds or fails, so it should go in the "script" section.  Failed commands in
the "install" section mark the build as "Errored".