### PR TITLE
Use StatsContext, TagKey, and TagValue types in more places.

### DIFF
--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -17,7 +17,6 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * A class that stores a singleton map from {@link MeasurementDescriptor.Name}s to
@@ -70,7 +69,7 @@ final class MeasurementDescriptorToViewMap {
   }
 
   // Records stats with a set of tags.
-  void record(Map<String, String> tags, MeasurementMap stats) {
+  void record(StatsContextImpl tags, MeasurementMap stats) {
     for (MeasurementValue mv : stats) {
       if (mv.getMeasurement()
           .getMeasurementDescriptorName()
@@ -80,7 +79,7 @@ final class MeasurementDescriptorToViewMap {
     }
   }
 
-  private void recordSupportedMeasurement(Map<String, String> tags, double value) {
+  private void recordSupportedMeasurement(StatsContextImpl tags, double value) {
     MutableView view = getMutableView(SupportedViews.SUPPORTED_VIEW);
     if (view == null) {
       throw new IllegalArgumentException("View not registered yet.");

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
@@ -81,7 +81,7 @@ abstract class MutableView {
 
     @Override
     void record(StatsContextImpl context, double value) {
-      Map<String, String> tags = context.tags;
+      Map<TagKey, TagValue> tags = context.tags;
       // TagKeys need to be unique within one view descriptor.
       final List<TagKey> tagKeys = this.distributionViewDescriptor.getTagKeys();
       if (tags.size() != tagKeys.size()) {
@@ -91,11 +91,11 @@ abstract class MutableView {
       final List<TagValue> tagValues = new ArrayList<TagValue>(tagKeys.size());
       for (int i = 0; i < tagKeys.size(); ++i) {
         TagKey tagKey = tagKeys.get(i);
-        if (!tags.containsKey(tagKey.asString())) {
+        if (!tags.containsKey(tagKey)) {
           // TODO(songya): need to determine how to handle incorrect or unregistered tags.
           return;
         }
-        tagValues.add(TagValue.create(tags.get(tagKey.asString())));
+        tagValues.add(tags.get(tagKey));
       }
 
       if (!tagValueDistributionMap.containsKey(tagValues)) {

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
@@ -45,7 +45,7 @@ abstract class MutableView {
   /**
    * Record stats with the given tags.
    */
-  abstract void record(Map<String, String> tags, double value);
+  abstract void record(StatsContextImpl tags, double value);
 
   /**
    * Convert this {@link MutableView} to {@link View}.
@@ -80,7 +80,8 @@ abstract class MutableView {
     }
 
     @Override
-    void record(Map<String, String> tags, double value) {
+    void record(StatsContextImpl context, double value) {
+      Map<String, String> tags = context.tags;
       // TagKeys need to be unique within one view descriptor.
       final List<TagKey> tagKeys = this.distributionViewDescriptor.getTagKeys();
       if (tags.size() != tagKeys.size()) {
@@ -183,7 +184,7 @@ abstract class MutableView {
     }
 
     @Override
-    void record(Map<String, String> tags, double value) {
+    void record(StatsContextImpl tags, double value) {
       throw new UnsupportedOperationException("Not implemented.");
     }
 

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextFactoryImpl.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
  * Native Implementation of {@link StatsContextFactory}.
  */
 final class StatsContextFactoryImpl extends StatsContextFactory {
-  static final StatsContextImpl DEFAULT = new StatsContextImpl(new HashMap<String, String>(0));
+  static final StatsContextImpl DEFAULT = new StatsContextImpl(new HashMap<TagKey, TagValue>(0));
 
   /**
    * Deserializes a {@link StatsContextImpl} from a serialized {@code CensusContextProto}.

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsContextImpl.java
@@ -23,9 +23,9 @@ import java.util.Map;
  * Native Implementation of {@link StatsContext}.
  */
 final class StatsContextImpl extends StatsContext {
-  final Map<String, String> tags;
+  final Map<TagKey, TagValue> tags;
 
-  StatsContextImpl(Map<String, String> tags) {
+  StatsContextImpl(Map<TagKey, TagValue> tags) {
     this.tags = tags;
   }
 
@@ -65,21 +65,21 @@ final class StatsContextImpl extends StatsContext {
   }
 
   private static final class Builder extends StatsContext.Builder {
-    private final HashMap<String, String> tags;
+    private final HashMap<TagKey, TagValue> tags;
 
-    private Builder(Map<String, String> tags) {
-      this.tags = new HashMap<String, String>(tags);
+    private Builder(Map<TagKey, TagValue> tags) {
+      this.tags = new HashMap<TagKey, TagValue>(tags);
     }
 
     @Override
     public Builder set(TagKey key, TagValue value) {
-      tags.put(key.toString(), value.toString());
+      tags.put(key, value);
       return this;
     }
 
     @Override
     public StatsContext build() {
-      return new StatsContextImpl(Collections.unmodifiableMap(new HashMap<String, String>(tags)));
+      return new StatsContextImpl(Collections.unmodifiableMap(new HashMap<TagKey, TagValue>(tags)));
     }
   }
 }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImpl.java
@@ -21,7 +21,6 @@ import com.google.instrumentation.stats.MutableView.MutableDistributionView;
 import com.google.instrumentation.stats.MutableView.MutableIntervalView;
 import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
 import com.google.instrumentation.stats.ViewDescriptor.IntervalViewDescriptor;
-import java.util.Map;
 
 /**
  * Native Implementation of {@link StatsManager}.
@@ -88,17 +87,17 @@ public final class StatsManagerImpl extends StatsManager {
    * @param measurementValues the measurements to record
    */
   void record(StatsContextImpl tags, MeasurementMap measurementValues) {
-    queue.enqueue(new StatsEvent(this, tags.tags, measurementValues));
+    queue.enqueue(new StatsEvent(this, tags, measurementValues));
   }
 
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).
   private static final class StatsEvent implements EventQueue.Entry {
-    private final Map<String, String> tags;
+    private final StatsContextImpl tags;
     private final MeasurementMap stats;
     private final StatsManagerImpl statsManager;
 
     StatsEvent(
-        StatsManagerImpl statsManager, Map<String, String> tags, MeasurementMap stats) {
+        StatsManagerImpl statsManager, StatsContextImpl tags, MeasurementMap stats) {
       this.statsManager = statsManager;
       this.tags = tags;
       this.stats = stats;

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsSerializer.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsSerializer.java
@@ -80,8 +80,8 @@ final class StatsSerializer {
     byteArrayOutputStream.write(VERSION_ID);
 
     // TODO(songya): add support for value types integer and boolean
-    Set<Entry<String, String>> tags = context.tags.entrySet();
-    for (Entry<String, String> tag : tags) {
+    Set<Entry<TagKey, TagValue>> tags = context.tags.entrySet();
+    for (Entry<TagKey, TagValue> tag : tags) {
       encodeStringTag(tag.getKey(), tag.getValue(), byteArrayOutputStream);
     }
     byteArrayOutputStream.writeTo(output);
@@ -92,7 +92,7 @@ final class StatsSerializer {
   static StatsContextImpl deserialize(InputStream input) throws IOException {
     try {
       byte[] bytes = ByteStreams.toByteArray(input);
-      HashMap<String, String> tags = new HashMap<String, String>();
+      HashMap<TagKey, TagValue> tags = new HashMap<TagKey, TagValue>();
       if (bytes.length == 0) {
         // Does not allow empty byte array.
         throw new IOException("Input byte stream can not be empty.");
@@ -110,8 +110,8 @@ final class StatsSerializer {
         int type = buffer.get();
         switch (type) {
           case VALUE_TYPE_STRING:
-            String key = decodeString(buffer);
-            String val = decodeString(buffer);
+            TagKey key = TagKey.create(decodeString(buffer));
+            TagValue val = TagValue.create(decodeString(buffer));
             tags.put(key, val);
             break;
           case VALUE_TYPE_INTEGER:
@@ -130,11 +130,11 @@ final class StatsSerializer {
 
   //  TODO(songya): Currently we only support encoding on string type.
   private static final void encodeStringTag(
-      String key, String value, ByteArrayOutputStream byteArrayOutputStream)
+      TagKey key, TagValue value, ByteArrayOutputStream byteArrayOutputStream)
       throws IOException {
     byteArrayOutputStream.write(VALUE_TYPE_STRING);
-    encodeString(key, byteArrayOutputStream);
-    encodeString(value, byteArrayOutputStream);
+    encodeString(key.asString(), byteArrayOutputStream);
+    encodeString(value.asString(), byteArrayOutputStream);
   }
 
   private static final void encodeString(String input, ByteArrayOutputStream byteArrayOutputStream)

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
@@ -34,10 +34,11 @@ public class StatsContextFactoryTest {
   private static final String KEY = "Key";
   private static final String VALUE_STRING = "String";
   private static final int VALUE_INT = 10;
-  private final HashMap<String, String> sampleTags = new HashMap<String, String>();
+  private final HashMap<TagKey, TagValue> sampleTags = new HashMap<TagKey, TagValue>();
 
   public StatsContextFactoryTest() {
-    sampleTags.put(KEY + StatsSerializer.VALUE_TYPE_STRING, VALUE_STRING);
+    sampleTags.put(
+        TagKey.create(KEY + StatsSerializer.VALUE_TYPE_STRING), TagValue.create(VALUE_STRING));
   }
 
   @Test
@@ -74,7 +75,7 @@ public class StatsContextFactoryTest {
 
   @Test
   public void testDeserializeMultipleString() throws Exception {
-    sampleTags.put("Key2", "String2");
+    sampleTags.put(TagKey.create("Key2"), TagValue.create("String2"));
     StatsContext expected = new StatsContextImpl(sampleTags);
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
@@ -42,11 +42,11 @@ public class StatsManagerImplTest {
   private static final TagValue tagValue1 = TagValue.create("some client method");
   private static final TagValue tagValue2 = TagValue.create("some other client method");
   private static final StatsContextImpl oneTag =
-          new StatsContextImpl(ImmutableMap.of(tagKey.asString(), tagValue1.asString()));
+          new StatsContextImpl(ImmutableMap.of(tagKey, tagValue1));
   private static final StatsContextImpl anotherTag =
-          new StatsContextImpl(ImmutableMap.of(tagKey.asString(), tagValue2.asString()));
+          new StatsContextImpl(ImmutableMap.of(tagKey, tagValue2));
   private static final StatsContextImpl wrongTag =
-          new StatsContextImpl(ImmutableMap.of("Wrong Tag Key", tagValue1.asString()));
+          new StatsContextImpl(ImmutableMap.of(TagKey.create("Wrong Tag Key"), tagValue1));
 
 
   private final StatsManagerImpl statsManager = new StatsManagerImpl(new SimpleEventQueue());


### PR DESCRIPTION
This just adds a little more type-safety.  ~~The first commit is from #236.~~  I don't want this PR to conflict with #233, so I will wait to merge it.