### PR TITLE
Move git history check out of "allow_failures" in .travis.yml.  Fixes #225.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
 
   - env: TASK=CHECK_GIT_HISTORY
 
-  allow_failures:
-  - env: TASK=CHECK_GIT_HISTORY
-
 before_install:
   - if \[ "$TASK" == "BUILD" \]; then
       mkdir -p $HOME/.gradle ;


### PR DESCRIPTION
We have been using the git history check for a few weeks, so I think it's safe
to enforce the check.