### PR TITLE
Change visibility for SpanFactory and StartSpanOptions (#240)

### DIFF
--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/BinaryPropagationHandlerImplBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/BinaryPropagationHandlerImplBenchmark.java
@@ -32,7 +32,7 @@ public class BinaryPropagationHandlerImplBenchmark {
   private static final SpanId spanId = SpanId.fromBytes(spanIdBytes);
   private static final byte[] traceOptionsBytes = new byte[] {1};
   private static final TraceOptions traceOptions = TraceOptions.fromBytes(traceOptionsBytes);
-  private static final SpanContext spanContext = new SpanContext(traceId, spanId, traceOptions);
+  private static final SpanContext spanContext = SpanContext.create(traceId, spanId, traceOptions);
   private static final BinaryPropagationHandler binaryPropagationHandler =
       BinaryPropagationHandlerImpl.INSTANCE;
   private static final byte[] spanContextBinary =

--- a/core/src/main/java/com/google/instrumentation/trace/SpanContext.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanContext.java
@@ -40,10 +40,8 @@ public final class SpanContext {
    * @param spanId the span identifier of the span context.
    * @param traceOptions the trace options for the span context.
    */
-  SpanContext(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {
-    this.traceId = traceId;
-    this.spanId = spanId;
-    this.traceOptions = traceOptions;
+  public static SpanContext create(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {
+    return new SpanContext(traceId, spanId, traceOptions);
   }
 
   /**
@@ -110,5 +108,11 @@ public final class SpanContext {
         .add("spanId", spanId)
         .add("traceOptions", traceOptions)
         .toString();
+  }
+
+  private SpanContext(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.traceOptions = traceOptions;
   }
 }

--- a/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
+++ b/core/src/main/java/com/google/instrumentation/trace/SpanFactory.java
@@ -16,7 +16,7 @@ package com.google.instrumentation.trace;
 import javax.annotation.Nullable;
 
 /** Factory class to create and start a {@link Span}. */
-abstract class SpanFactory {
+public abstract class SpanFactory {
   /**
    * Creates and starts a new child {@link Span} (or root if parent is {@code null}), with parent
    * being the designated {@code Span} and the given options.
@@ -26,7 +26,7 @@ abstract class SpanFactory {
    * @param options The options for the start of the {@code Span}.
    * @return A child {@code Span} that will have the name provided.
    */
-  abstract Span startSpan(@Nullable Span parent, String name, StartSpanOptions options);
+  protected abstract Span startSpan(@Nullable Span parent, String name, StartSpanOptions options);
 
   /**
    * Creates and starts a new child {@link Span} (or root if parent is {@code null}), with parent
@@ -39,6 +39,6 @@ abstract class SpanFactory {
    * @param options The options for the start of the {@code Span}.
    * @return A child {@code Span} that will have the name provided.
    */
-  abstract Span startSpanWithRemoteParent(
+  protected abstract Span startSpanWithRemoteParent(
       @Nullable SpanContext remoteParent, String name, StartSpanOptions options);
 }

--- a/core/src/main/java/com/google/instrumentation/trace/StartSpanOptions.java
+++ b/core/src/main/java/com/google/instrumentation/trace/StartSpanOptions.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
  * overriding the {@link Sampler sampler}, the parent links, and option to record all the events
  * even if the {@code Span} is not sampled.
  */
-final class StartSpanOptions {
+public final class StartSpanOptions {
   private Sampler sampler;
   private List<Span> parentLinks;
   private Boolean recordEvents;
@@ -40,7 +40,7 @@ final class StartSpanOptions {
    * @return the {@code Sampler} to be used, or {@code null} if default.
    */
   @Nullable
-  Sampler getSampler() {
+  public Sampler getSampler() {
     return sampler;
   }
 
@@ -49,7 +49,7 @@ final class StartSpanOptions {
    *
    * @return the parent links to be set for the {@code Span}.
    */
-  List<Span> getParentLinks() {
+  public List<Span> getParentLinks() {
     // Return an unmodifiable list.
     return parentLinks == null
         ? Collections.<Span>emptyList()
@@ -62,7 +62,7 @@ final class StartSpanOptions {
    * @return the record events option setting.
    */
   @Nullable
-  Boolean getRecordEvents() {
+  public Boolean getRecordEvents() {
     return recordEvents;
   }
 

--- a/core/src/main/java/com/google/instrumentation/trace/Tracer.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Tracer.java
@@ -210,12 +210,12 @@ public abstract class Tracer {
     // No-op implementation of the SpanFactory
     private static final class NoopSpanFactory extends SpanFactory {
       @Override
-      Span startSpan(@Nullable Span parent, String name, StartSpanOptions options) {
+      protected Span startSpan(@Nullable Span parent, String name, StartSpanOptions options) {
         return BlankSpan.INSTANCE;
       }
 
       @Override
-      Span startSpanWithRemoteParent(
+      protected Span startSpanWithRemoteParent(
           @Nullable SpanContext remoteParent, String name, StartSpanOptions options) {
         return BlankSpan.INSTANCE;
       }

--- a/core/src/test/java/com/google/instrumentation/trace/LinkTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/LinkTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.testing.EqualsTester;
 import com.google.instrumentation.trace.Link.Type;
 import java.util.Random;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,18 +25,10 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link Link}. */
 @RunWith(JUnit4.class)
 public class LinkTest {
-  private Random random;
-  private SpanContext spanContext;
-
-  @Before
-  public void setUp() {
-    random = new Random(1234);
-    spanContext =
-        new SpanContext(
-            TraceId.generateRandomId(random),
-            SpanId.generateRandomId(random),
-            TraceOptions.DEFAULT);
-  }
+  private final Random random = new Random(1234);
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
 
   @Test
   public void fromSpanContext_ChildLink() {

--- a/core/src/test/java/com/google/instrumentation/trace/SamplersTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SamplersTest.java
@@ -24,29 +24,33 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link Samplers}. */
 @RunWith(JUnit4.class)
 public class SamplersTest {
+  private final Random random = new Random(1234);
+  private final TraceId traceId = TraceId.generateRandomId(random);
+  private final SpanId parentSpanId = SpanId.generateRandomId(random);
+  private final SpanId spanId = SpanId.generateRandomId(random);
+  private final SpanContext sampledSpanContext =
+      SpanContext.create(traceId, parentSpanId, TraceOptions.builder().setIsSampled().build());
+  private final SpanContext notSampledSpanContext =
+      SpanContext.create(traceId, parentSpanId, TraceOptions.DEFAULT);
+
   @Test
   public void alwaysSampleSampler_AlwaysReturnTrue() {
-    Random random = new Random(1234);
-    TraceId traceId = TraceId.generateRandomId(random);
-    SpanId parentSpanId = SpanId.generateRandomId(random);
-    SpanId spanId = SpanId.generateRandomId(random);
-    // Traced parent.
+    // Sampled parent.
     assertThat(
             Samplers.alwaysSample()
                 .shouldSample(
-                    new SpanContext(
-                        traceId, parentSpanId, TraceOptions.builder().setIsSampled().build()),
+                    sampledSpanContext,
                     false,
                     traceId,
                     spanId,
                     "Another name",
                     Collections.<Span>emptyList()))
         .isTrue();
-    // Untraced parent.
+    // Not sampled parent.
     assertThat(
             Samplers.alwaysSample()
                 .shouldSample(
-                    new SpanContext(traceId, parentSpanId, TraceOptions.DEFAULT),
+                    notSampledSpanContext,
                     false,
                     traceId,
                     spanId,
@@ -62,27 +66,22 @@ public class SamplersTest {
 
   @Test
   public void neverSampleSampler_AlwaysReturnFalse() {
-    Random random = new Random(1234);
-    TraceId traceId = TraceId.generateRandomId(random);
-    SpanId parentSpanId = SpanId.generateRandomId(random);
-    SpanId spanId = SpanId.generateRandomId(random);
-    // Traced parent.
+    // Sampled parent.
     assertThat(
             Samplers.neverSample()
                 .shouldSample(
-                    new SpanContext(
-                        traceId, parentSpanId, TraceOptions.builder().setIsSampled().build()),
+                    sampledSpanContext,
                     false,
                     traceId,
                     spanId,
                     "bar",
                     Collections.<Span>emptyList()))
         .isFalse();
-    // Untraced parent.
+    // Not sampled parent.
     assertThat(
             Samplers.neverSample()
                 .shouldSample(
-                    new SpanContext(traceId, parentSpanId, TraceOptions.DEFAULT),
+                    notSampledSpanContext,
                     false,
                     traceId,
                     spanId,

--- a/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanBuilderTest.java
@@ -36,21 +36,17 @@ import org.mockito.MockitoAnnotations;
 public class SpanBuilderTest {
   private static final String SPAN_NAME = "MySpanName";
   private static final Tracer tracer = Tracing.getTracer();
+  private final Random random = new Random(1234);
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
   @Mock private Span span;
   @Mock private SpanFactory spanFactory;
-  private Random random;
-  private SpanContext spanContext;
   private SpanBuilder spanBuilder;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    random = new Random(1234);
-    spanContext =
-        new SpanContext(
-            TraceId.generateRandomId(random),
-            SpanId.generateRandomId(random),
-            TraceOptions.DEFAULT);
     spanBuilder = SpanBuilder.builder(spanFactory, BlankSpan.INSTANCE, SPAN_NAME);
   }
 

--- a/core/src/test/java/com/google/instrumentation/trace/SpanContextTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanContextTest.java
@@ -29,14 +29,13 @@ public class SpanContextTest {
       new byte[] {0, 0, 0, 0, 0, 0, 0, '0', 0, 0, 0, 0, 0, 0, 0, 0};
   private static final byte[] firstSpanIdBytes = new byte[] {0, 0, 0, 0, 0, 0, 0, 'a'};
   private static final byte[] secondSpanIdBytes = new byte[] {'0', 0, 0, 0, 0, 0, 0, 0};
-
   private static final SpanContext first =
-      new SpanContext(
+      SpanContext.create(
           TraceId.fromBytes(firstTraceIdBytes),
           SpanId.fromBytes(firstSpanIdBytes),
           TraceOptions.DEFAULT);
   private static final SpanContext second =
-      new SpanContext(
+      SpanContext.create(
           TraceId.fromBytes(secondTraceIdBytes),
           SpanId.fromBytes(secondSpanIdBytes),
           TraceOptions.builder().setIsSampled().build());
@@ -52,12 +51,12 @@ public class SpanContextTest {
   public void isValid() {
     assertThat(SpanContext.INVALID.isValid()).isFalse();
     assertThat(
-            new SpanContext(
+            SpanContext.create(
                     TraceId.fromBytes(firstTraceIdBytes), SpanId.INVALID, TraceOptions.DEFAULT)
                 .isValid())
         .isFalse();
     assertThat(
-            new SpanContext(
+            SpanContext.create(
                     TraceId.INVALID, SpanId.fromBytes(firstSpanIdBytes), TraceOptions.DEFAULT)
                 .isValid())
         .isFalse();
@@ -88,13 +87,13 @@ public class SpanContextTest {
     EqualsTester tester = new EqualsTester();
     tester.addEqualityGroup(
         first,
-        new SpanContext(
+        SpanContext.create(
             TraceId.fromBytes(firstTraceIdBytes),
             SpanId.fromBytes(firstSpanIdBytes),
             TraceOptions.DEFAULT));
     tester.addEqualityGroup(
         second,
-        new SpanContext(
+        SpanContext.create(
             TraceId.fromBytes(secondTraceIdBytes),
             SpanId.fromBytes(secondSpanIdBytes),
             TraceOptions.builder().setIsSampled().build()));

--- a/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/SpanTest.java
@@ -38,12 +38,12 @@ public class SpanTest {
   public void setUp() {
     random = new Random(1234);
     spanContext =
-        new SpanContext(
+        SpanContext.create(
             TraceId.generateRandomId(random),
             SpanId.generateRandomId(random),
             TraceOptions.builder().setIsSampled().build());
     notSampledSpanContext =
-        new SpanContext(
+        SpanContext.create(
             TraceId.generateRandomId(random),
             SpanId.generateRandomId(random),
             TraceOptions.DEFAULT);

--- a/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/TracerTest.java
@@ -188,7 +188,7 @@ public class TracerTest {
     Random random = new Random(1234);
     Tracer mockTracer = new MockTracer(spanFactory);
     SpanContext spanContext =
-        new SpanContext(
+        SpanContext.create(
             TraceId.generateRandomId(random),
             SpanId.generateRandomId(random),
             TraceOptions.DEFAULT);

--- a/core/src/test/java/com/google/instrumentation/trace/TracingTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/TracingTest.java
@@ -43,7 +43,7 @@ public class TracingTest {
   @Test
   public void loadSpanFactory_IgnoresMissingClasses() {
     assertThat(
-        Tracing.loadTraceComponent(
+            Tracing.loadTraceComponent(
                     new ClassLoader() {
                       @Override
                       public Class<?> loadClass(String name) throws ClassNotFoundException {

--- a/core_impl/src/main/java/com/google/instrumentation/trace/BinaryPropagationHandlerImpl.java
+++ b/core_impl/src/main/java/com/google/instrumentation/trace/BinaryPropagationHandlerImpl.java
@@ -107,7 +107,7 @@ final class BinaryPropagationHandlerImpl extends BinaryPropagationHandler {
       if (bytes.length > pos && bytes[pos] == TRACE_OPTION_FIELD_ID) {
         traceOptions = TraceOptions.fromBytes(bytes, pos + ID_SIZE);
       }
-      return new SpanContext(traceId, spanId, traceOptions);
+      return SpanContext.create(traceId, spanId, traceOptions);
     } catch (IndexOutOfBoundsException e) {
       throw new ParseException("Invalid input: " + e.toString(), pos);
     }

--- a/core_impl/src/test/java/com/google/instrumentation/trace/BinaryPropagationHandlerImplTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/trace/BinaryPropagationHandlerImplTest.java
@@ -39,13 +39,14 @@ public class BinaryPropagationHandlerImplTest {
         101, 102, 103, 104, 2, 1
       };
   private static final SpanContext EXAMPLE_SPAN_CONTEXT =
-      new SpanContext(TRACE_ID, SPAN_ID, TRACE_OPTIONS);
+      SpanContext.create(TRACE_ID, SPAN_ID, TRACE_OPTIONS);
   @Rule public ExpectedException expectedException = ExpectedException.none();
   private static final BinaryPropagationHandler binaryPropagationHandler =
       BinaryPropagationHandlerImpl.INSTANCE;
 
   private static void testSpanContextConversion(SpanContext spanContext) throws ParseException {
-    SpanContext propagatedBinarySpanContext = binaryPropagationHandler.fromBinaryValue(
+    SpanContext propagatedBinarySpanContext =
+        binaryPropagationHandler.fromBinaryValue(
             binaryPropagationHandler.toBinaryValue(spanContext));
 
     assertWithMessage("Binary propagated context is not equal with the initial context.")
@@ -56,12 +57,12 @@ public class BinaryPropagationHandlerImplTest {
   @Test
   public void propagate_SpanContextTracingEnabled() throws ParseException {
     testSpanContextConversion(
-        new SpanContext(TRACE_ID, SPAN_ID, TraceOptions.builder().setIsSampled().build()));
+        SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.builder().setIsSampled().build()));
   }
 
   @Test
   public void propagate_SpanContextNoTracing() throws ParseException {
-    testSpanContextConversion(new SpanContext(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT));
+    testSpanContextConversion(SpanContext.create(TRACE_ID, SPAN_ID, TraceOptions.DEFAULT));
   }
 
   @Test(expected = NullPointerException.class)
@@ -114,7 +115,7 @@ public class BinaryPropagationHandlerImplTest {
                   0, 4, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97, 98,
                   99, 100, 101, 102, 103, 104, 2, 1
                 }))
-        .isEqualTo(new SpanContext(TraceId.INVALID, SpanId.INVALID, TraceOptions.DEFAULT));
+        .isEqualTo(SpanContext.create(TraceId.INVALID, SpanId.INVALID, TraceOptions.DEFAULT));
   }
 
   @Test
@@ -126,7 +127,7 @@ public class BinaryPropagationHandlerImplTest {
                   99, 100, 101, 102, 103, 104, 2, 1
                 }))
         .isEqualTo(
-            new SpanContext(
+            SpanContext.create(
                 TraceId.fromBytes(
                     new byte[] {64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}),
                 SpanId.INVALID,

--- a/core_impl/src/test/java/com/google/instrumentation/trace/SpanDataTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/trace/SpanDataTest.java
@@ -38,9 +38,11 @@ public class SpanDataTest {
   private static final String DISPLAY_NAME = "MySpanDisplayName";
   private static final String ANNOTATION_TEXT = "MyAnnotationText";
   private static final Status status = Status.DEADLINE_EXCEEDED.withDescription("TooSlow");
-  private Random random;
-  private SpanContext spanContext;
-  private SpanId parentSpanId;
+  private final Random random = new Random(1234);
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
+  private final SpanId parentSpanId = SpanId.generateRandomId(random);
   private final Map<String, AttributeValue> attributes = new HashMap<String, AttributeValue>();
   private final List<TimedEvent<Annotation>> annotations = new LinkedList<TimedEvent<Annotation>>();
   private final List<TimedEvent<NetworkEvent>> networkEvents =
@@ -49,13 +51,6 @@ public class SpanDataTest {
 
   @Before
   public void setUp() {
-    random = new Random(1234);
-    spanContext =
-        new SpanContext(
-            TraceId.generateRandomId(random),
-            SpanId.generateRandomId(random),
-            TraceOptions.DEFAULT);
-    parentSpanId = SpanId.generateRandomId(random);
     annotations.add(
         new TimedEvent<Annotation>(eventTimestamp1, Annotation.fromDescription(ANNOTATION_TEXT)));
     annotations.add(


### PR DESCRIPTION
* Change visibility for SpanFactory and StartSpanOptions to allow testing and implementation. Add a public SpanContext.create. Make SpanFactory methods protected and StartSpanOptions getters public.

(cherry picked from commit 473af8e4205feac693b5f40d91824e0c5102b849)