### PR TITLE
Move StringUtil into the "internal" package.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/internal/StringUtil.java
+++ b/core/src/main/java/com/google/instrumentation/internal/StringUtil.java
@@ -11,17 +11,25 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.stats;
+package com.google.instrumentation.internal;
 
 /**
- * Utility methods for working with tag keys, tag values, and metric names.
+ * Internal utility methods for working with tag keys, tag values, and metric names.
  */
-final class StringUtil {
+public final class StringUtil {
 
-  static final int MAX_LENGTH = 255;
-  static final char UNPRINTABLE_CHAR_SUBSTITUTE = '_';
+  public static final int MAX_LENGTH = 255;
+  public static final char UNPRINTABLE_CHAR_SUBSTITUTE = '_';
 
-  static String sanitize(String str) {
+  /**
+   * Replaces non-printable characters with underscores and truncates to {@link
+   * StringUtil#MAX_LENGTH}.
+   *
+   * @param str the {@code String} to be sanitized.
+   * @return the {@code String} with all non-printable characters replaced by underscores, truncated
+   *     to {@code MAX_LENGTH}.
+   */
+  public static String sanitize(String str) {
     if (str.length() > MAX_LENGTH) {
       str = str.substring(0, MAX_LENGTH);
     }

--- a/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/MeasurementDescriptor.java
@@ -14,7 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
-
+import com.google.instrumentation.internal.StringUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/core/src/main/java/com/google/instrumentation/stats/TagKey.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagKey.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
 
 /**
  * Tag keys.

--- a/core/src/main/java/com/google/instrumentation/stats/TagValue.java
+++ b/core/src/main/java/com/google/instrumentation/stats/TagValue.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.stats;
 
 import com.google.auto.value.AutoValue;
+import com.google.instrumentation.internal.StringUtil;
 
 /**
  * Tag values.

--- a/core/src/test/java/com/google/instrumentation/internal/StringUtilTest.java
+++ b/core/src/test/java/com/google/instrumentation/internal/StringUtilTest.java
@@ -11,10 +11,11 @@
  * limitations under the License.
  */
 
-package com.google.instrumentation.stats;
+package com.google.instrumentation.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import com.google.instrumentation.stats.MeasurementDescriptor.BasicUnit;
 import com.google.instrumentation.stats.MeasurementDescriptor.MeasurementUnit;
 import java.util.Arrays;

--- a/core/src/test/java/com/google/instrumentation/stats/TagKeyTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/TagKeyTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/com/google/instrumentation/stats/TagValueTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/TagValueTest.java
@@ -16,6 +16,7 @@ package com.google.instrumentation.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
+import com.google.instrumentation.internal.StringUtil;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
This will allow the class to be used by multiple packages.

This commit was part of #219.