### PR TITLE
Make the TraceOptions Builder methods public for testing. (#247)

### DIFF
--- a/core/src/main/java/com/google/instrumentation/trace/TraceOptions.java
+++ b/core/src/main/java/com/google/instrumentation/trace/TraceOptions.java
@@ -183,7 +183,7 @@ public final class TraceOptions {
      *
      * @return this.
      */
-    Builder setIsSampled() {
+    public Builder setIsSampled() {
       options |= IS_SAMPLED;
       return this;
     }
@@ -193,7 +193,7 @@ public final class TraceOptions {
      *
      * @return a {@code TraceOptions} with the desired options.
      */
-    TraceOptions build() {
+    public TraceOptions build() {
       return new TraceOptions(options);
     }
   }


### PR DESCRIPTION
(cherry picked from commit cfe26b220b4731b3c95fea03058131db565a615d)