### PR TITLE
Make auto-value compileOnly dependency.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,10 +1,9 @@
 description = 'Instrumentation: API'
 
 dependencies {
-    compile libraries.auto_value,
-            libraries.grpc_context,
+    compile libraries.grpc_context,
             libraries.guava
-
+    compileOnly libraries.auto_value
     testCompile libraries.grpc_context
 
     signature "org.codehaus.mojo.signature:java16:+@signature"


### PR DESCRIPTION
Because it's not needed at runtime.  With `compile`, auto-value is downloaded by downstream users, which triggers warnings like `warning: No processor claimed any of these annotations: ` with error-prone compiler (grpc/grpc-java/pull/2938). With `compileOnly`, auto-value is not downloaded by downstream users.