### PR TITLE
Make auto-value compileOnly dependency. (#254)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,10 +1,9 @@
 description = 'Instrumentation: API'
 
 dependencies {
-    compile libraries.auto_value,
-            libraries.grpc_context,
+    compile libraries.grpc_context,
             libraries.guava
-
+    compileOnly libraries.auto_value
     testCompile libraries.grpc_context
 
     signature "org.codehaus.mojo.signature:java16:+@signature"


### PR DESCRIPTION
Because it's not needed at runtime.  Having it in runtime classpath
triggers warnings like `warning: No processor claimed any of these
annotations: ` with error-prone compiler (grpc/grpc-java/pull/2938)
(cherry picked from commit a19c013692a0c2a61652da67add51d10ba81ebf1)