### PR TITLE
Add Clock implementations for Java 6/7 and for testing.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/internal/MillisClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/MillisClock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.internal;
+
+import com.google.instrumentation.common.Clock;
+import com.google.instrumentation.common.Timestamp;
+
+/**
+ * A {@link Clock} that uses {@link System#currentTimeMillis()} and {@link System#nanoTime()}.
+ */
+public final class MillisClock extends Clock {
+  private static final MillisClock INSTANCE = new MillisClock();
+
+  private MillisClock() {}
+
+  /**
+   * Returns a {@code MillisClock}.
+   *
+   * @return a {@code MillisClock}.
+   */
+  public static MillisClock getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public Timestamp now() {
+    return Timestamp.fromMillis(System.currentTimeMillis());
+  }
+
+  @Override
+  public long nowNanos() {
+    return System.nanoTime();
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/internal/MillisClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/MillisClock.java
@@ -15,10 +15,12 @@ package com.google.instrumentation.internal;
 
 import com.google.instrumentation.common.Clock;
 import com.google.instrumentation.common.Timestamp;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link Clock} that uses {@link System#currentTimeMillis()} and {@link System#nanoTime()}.
  */
+@ThreadSafe
 public final class MillisClock extends Clock {
   private static final MillisClock INSTANCE = new MillisClock();
 

--- a/core/src/main/java/com/google/instrumentation/internal/TestClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/TestClock.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.internal;
+
+import com.google.instrumentation.common.Clock;
+import com.google.instrumentation.common.Timestamp;
+import java.math.BigInteger;
+
+/**
+ * A {@link Clock} that allows the time to be set for testing.
+ */
+public final class TestClock extends Clock {
+  private static final int NUM_NANOS_PER_SECOND = 1000 * 1000 * 1000;
+
+  private Timestamp currentTime = Timestamp.create(0, 0);
+
+  private TestClock() {}
+
+  /**
+   * Creates a clock initialized to time 0.
+   *
+   * @return a clock initialized to time 0.
+   */
+  public static TestClock create() {
+    return new TestClock();
+  }
+
+  /**
+   * Creates a clock with the given time.
+   *
+   * @param time the initial time.
+   * @return a new {@code TestClock} with the given time.
+   */
+  public static TestClock create(Timestamp time) {
+    TestClock clock = new TestClock();
+    clock.setTime(time);
+    return clock;
+  }
+
+  /**
+   * Sets the time.
+   *
+   * @param time the new time.
+   */
+  public void setTime(Timestamp time) {
+    currentTime = validateNanos(time);
+  }
+
+  @Override
+  public Timestamp now() {
+    return currentTime;
+  }
+
+  @Override
+  public long nowNanos() {
+    return getNanos(currentTime).longValue();
+  }
+
+  private static Timestamp validateNanos(Timestamp time) {
+    BigInteger nanos = getNanos(time);
+    if (nanos.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0
+        || nanos.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {
+      throw new ArithmeticException("Nanoseconds overflow: " + time);
+    }
+    return time;
+  }
+
+  // Converts Timestamp into nanoseconds since time 0.
+  private static BigInteger getNanos(Timestamp time) {
+    return BigInteger.valueOf(time.getSeconds())
+        .multiply(BigInteger.valueOf(NUM_NANOS_PER_SECOND))
+        .add(BigInteger.valueOf(time.getNanos()));
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/internal/TestClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/TestClock.java
@@ -15,6 +15,7 @@ package com.google.instrumentation.internal;
 
 import com.google.common.math.LongMath;
 import com.google.instrumentation.common.Clock;
+import com.google.instrumentation.common.Duration;
 import com.google.instrumentation.common.Timestamp;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
@@ -59,6 +60,21 @@ public final class TestClock extends Clock {
    */
   public synchronized void setTime(Timestamp time) {
     currentTime = validateNanos(time);
+  }
+
+  /**
+   * Advances the time by a duration.
+   *
+   * @param duration the increase in time.
+   */
+  // TODO(sebright): Consider adding an 'addDuration' method to Timestamp.
+  public synchronized void advanceTime(Duration duration) {
+    currentTime =
+        validateNanos(
+            Timestamp.create(
+                    LongMath.checkedAdd(currentTime.getSeconds(), duration.getSeconds()),
+                    currentTime.getNanos())
+                .addNanos(duration.getNanos()));
   }
 
   @Override

--- a/core/src/main/java/com/google/instrumentation/internal/TestClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/TestClock.java
@@ -16,13 +16,17 @@ package com.google.instrumentation.internal;
 import com.google.common.math.LongMath;
 import com.google.instrumentation.common.Clock;
 import com.google.instrumentation.common.Timestamp;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link Clock} that allows the time to be set for testing.
  */
+@ThreadSafe
 public final class TestClock extends Clock {
   private static final int NUM_NANOS_PER_SECOND = 1000 * 1000 * 1000;
 
+  @GuardedBy("this")
   private Timestamp currentTime = Timestamp.create(0, 0);
 
   private TestClock() {}
@@ -53,17 +57,17 @@ public final class TestClock extends Clock {
    *
    * @param time the new time.
    */
-  public void setTime(Timestamp time) {
+  public synchronized void setTime(Timestamp time) {
     currentTime = validateNanos(time);
   }
 
   @Override
-  public Timestamp now() {
+  public synchronized Timestamp now() {
     return currentTime;
   }
 
   @Override
-  public long nowNanos() {
+  public synchronized long nowNanos() {
     return getNanos(currentTime);
   }
 

--- a/core/src/main/java/com/google/instrumentation/internal/TestClock.java
+++ b/core/src/main/java/com/google/instrumentation/internal/TestClock.java
@@ -13,9 +13,9 @@
 
 package com.google.instrumentation.internal;
 
+import com.google.common.math.LongMath;
 import com.google.instrumentation.common.Clock;
 import com.google.instrumentation.common.Timestamp;
-import java.math.BigInteger;
 
 /**
  * A {@link Clock} that allows the time to be set for testing.
@@ -64,22 +64,17 @@ public final class TestClock extends Clock {
 
   @Override
   public long nowNanos() {
-    return getNanos(currentTime).longValue();
+    return getNanos(currentTime);
   }
 
   private static Timestamp validateNanos(Timestamp time) {
-    BigInteger nanos = getNanos(time);
-    if (nanos.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0
-        || nanos.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) {
-      throw new ArithmeticException("Nanoseconds overflow: " + time);
-    }
+    getNanos(time);
     return time;
   }
 
-  // Converts Timestamp into nanoseconds since time 0.
-  private static BigInteger getNanos(Timestamp time) {
-    return BigInteger.valueOf(time.getSeconds())
-        .multiply(BigInteger.valueOf(NUM_NANOS_PER_SECOND))
-        .add(BigInteger.valueOf(time.getNanos()));
+  // Converts Timestamp into nanoseconds since time 0 and throws an exception if it overflows.
+  private static long getNanos(Timestamp time) {
+    return LongMath.checkedAdd(
+        LongMath.checkedMultiply(time.getSeconds(), NUM_NANOS_PER_SECOND), time.getNanos());
   }
 }

--- a/core/src/test/java/com/google/instrumentation/internal/TestClockTest.java
+++ b/core/src/test/java/com/google/instrumentation/internal/TestClockTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.instrumentation.common.Timestamp;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TestClock}.
+ */
+@RunWith(JUnit4.class)
+public final class TestClockTest {
+  private static final int NUM_NANOS_PER_SECOND = 1000 * 1000 * 1000;
+
+  @Test
+  public void setAndGetTime() {
+    TestClock clock = TestClock.create(Timestamp.create(1, 2));
+    assertThat(clock.now()).isEqualTo(Timestamp.create(1, 2));
+    clock.setTime(Timestamp.create(3, 4));
+    assertThat(clock.now()).isEqualTo(Timestamp.create(3, 4));
+  }
+
+  @Test
+  public void measureElapsedTime() {
+    TestClock clock = TestClock.create(Timestamp.create(10, 1));
+    long nanos1 = clock.nowNanos();
+    clock.setTime(Timestamp.create(11, 5));
+    long nanos2 = clock.nowNanos();
+    assertThat(nanos2 - nanos1).isEqualTo(1000 * 1000 * 1000 + 4);
+  }
+
+  @Test(expected = ArithmeticException.class)
+  public void catchOverflow() {
+    TestClock.create(Timestamp.create(Long.MAX_VALUE / NUM_NANOS_PER_SECOND + 1, 0));
+  }
+
+  @Test(expected = ArithmeticException.class)
+  public void catchNegativeOverflow() {
+    TestClock.create(Timestamp.create(Long.MIN_VALUE / NUM_NANOS_PER_SECOND - 1, 0));
+  }
+}

--- a/core/src/test/java/com/google/instrumentation/internal/TestClockTest.java
+++ b/core/src/test/java/com/google/instrumentation/internal/TestClockTest.java
@@ -15,6 +15,7 @@ package com.google.instrumentation.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.instrumentation.common.Duration;
 import com.google.instrumentation.common.Timestamp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +34,13 @@ public final class TestClockTest {
     assertThat(clock.now()).isEqualTo(Timestamp.create(1, 2));
     clock.setTime(Timestamp.create(3, 4));
     assertThat(clock.now()).isEqualTo(Timestamp.create(3, 4));
+  }
+
+  @Test
+  public void advanceTime() {
+    TestClock clock = TestClock.create(Timestamp.create(1, 500 * 1000 * 1000));
+    clock.advanceTime(Duration.create(2, 600 * 1000 * 1000));
+    assertThat(clock.now()).isEqualTo(Timestamp.create(4, 100 * 1000 * 1000));
   }
 
   @Test


### PR DESCRIPTION
The two implementations are in the `internal` package for now.

/cc @adriancole 