### PR TITLE
MeasurementDescriptorToViewMap synchronization

### DIFF
--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -57,7 +57,7 @@ final class MeasurementDescriptorToViewMap {
 
   /** Enable stats collection for the given {@link ViewDescriptor}. */
   synchronized void registerView(ViewDescriptor viewDescriptor, Clock clock) {
-    if (getView(viewDescriptor, clock) != null) {
+    if (getMutableView(viewDescriptor) != null) {
       // Ignore views that are already registered.
       return;
     }

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -40,14 +40,8 @@ final class MeasurementDescriptorToViewMap {
 
   /** Returns a {@link View} corresponding to the given {@link ViewDescriptor}. */
   synchronized View getView(ViewDescriptor viewDescriptor, Clock clock) {
-    Collection<MutableView> views =
-        mutableMap.get(viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName());
-    for (MutableView view : views) {
-      if (view.getViewDescriptor().equals(viewDescriptor)) {
-        return view.toView(clock);
-      }
-    }
-    return null;
+    MutableView view = getMutableView(viewDescriptor);
+    return view == null ? null : view.toView(clock);
   }
 
   private synchronized MutableView getMutableView(ViewDescriptor viewDescriptor) {

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -36,7 +36,7 @@ final class MeasurementDescriptorToViewMap {
   /**
    * Returns a {@link View} corresponding to the given {@link ViewDescriptor}.
    */
-  final View getView(ViewDescriptor viewDescriptor, Clock clock) {
+  View getView(ViewDescriptor viewDescriptor, Clock clock) {
     Collection<MutableView> views = mutableMap.get(
         viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName());
     synchronized (mutableMap) {
@@ -49,7 +49,7 @@ final class MeasurementDescriptorToViewMap {
     return null;
   }
 
-  private final MutableView getMutableView(ViewDescriptor viewDescriptor) {
+  private MutableView getMutableView(ViewDescriptor viewDescriptor) {
     Collection<MutableView> views = mutableMap.get(
         viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName());
     synchronized (mutableMap) {

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MutableView.java
@@ -15,7 +15,6 @@ package com.google.instrumentation.stats;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.instrumentation.common.Clock;
-import com.google.instrumentation.common.Function;
 import com.google.instrumentation.common.Timestamp;
 import com.google.instrumentation.stats.View.DistributionView;
 import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
@@ -29,7 +28,6 @@ import java.util.Map.Entry;
 /**
  * A mutable version of {@link View}, used for recording stats and start/end time.
  */
-// TODO(songya): remove or modify the methods of this class, since it's not part of the API.
 abstract class MutableView {
   // TODO(songya): might want to update the default tag value later.
   @VisibleForTesting static final TagValue UNKNOWN_TAG_VALUE = TagValue.create("unknown/not set");
@@ -38,13 +36,6 @@ abstract class MutableView {
    * The {@link ViewDescriptor} associated with this {@link View}.
    */
   abstract ViewDescriptor getViewDescriptor();
-
-  /**
-   * Applies the given match function to the underlying data type.
-   */
-  abstract <T> T match(
-      Function<MutableDistributionView, T> p0,
-      Function<MutableIntervalView, T> p1);
 
   /**
    * Record stats with the given tags.
@@ -75,12 +66,6 @@ abstract class MutableView {
     @Override
     ViewDescriptor getViewDescriptor() {
       return distributionViewDescriptor;
-    }
-
-    @Override
-    <T> T match(
-        Function<MutableDistributionView, T> p0, Function<MutableIntervalView, T> p1) {
-      return p0.apply(this);
     }
 
     @Override
@@ -178,12 +163,6 @@ abstract class MutableView {
 
     @Override
     ViewDescriptor getViewDescriptor() {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    <T> T match(
-        Function<MutableDistributionView, T> p0, Function<MutableIntervalView, T> p1) {
       throw new UnsupportedOperationException("Not implemented.");
     }
 

--- a/core_impl/src/main/java/com/google/instrumentation/stats/ViewManager.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/ViewManager.java
@@ -63,17 +63,17 @@ final class ViewManager {
   private static final class StatsEvent implements EventQueue.Entry {
     private final StatsContextImpl tags;
     private final MeasurementMap stats;
-    private final ViewManager statsCollector;
+    private final ViewManager viewManager;
 
-    StatsEvent(ViewManager statsCollector, StatsContextImpl tags, MeasurementMap stats) {
-      this.statsCollector = statsCollector;
+    StatsEvent(ViewManager viewManager, StatsContextImpl tags, MeasurementMap stats) {
+      this.viewManager = viewManager;
       this.tags = tags;
       this.stats = stats;
     }
 
     @Override
     public void process() {
-      statsCollector.measurementDescriptorToViewMap.record(tags, stats);
+      viewManager.measurementDescriptorToViewMap.record(tags, stats);
     }
   }
 }

--- a/core_impl/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMapTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMapTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
 import com.google.instrumentation.common.Function;
 import com.google.instrumentation.common.Timestamp;
 import com.google.instrumentation.internal.TestClock;
-import com.google.instrumentation.stats.MutableView.MutableDistributionView;
 import com.google.instrumentation.stats.View.DistributionView;
 import com.google.instrumentation.stats.View.IntervalView;
 import org.junit.Test;
@@ -34,11 +33,10 @@ public class MeasurementDescriptorToViewMapTest {
       new MeasurementDescriptorToViewMap();
 
   @Test
-  public void testPutAndGetView() {
+  public void testRegisterAndGetView() {
     TestClock clock = TestClock.create(Timestamp.create(10, 20));
-    measurementDescriptorToViewMap.putView(
-        RpcMeasurementConstants.RPC_CLIENT_ROUNDTRIP_LATENCY.getMeasurementDescriptorName(),
-        MutableDistributionView.create(RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW, clock.now()));
+    measurementDescriptorToViewMap.registerView(
+        RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW, clock);
     clock.setTime(Timestamp.create(30, 40));
     View actual = measurementDescriptorToViewMap.getView(RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW, clock);
     actual.match(


### PR DESCRIPTION
Two main commits:

#### Refactor MeasurementDescriptorToViewMap.putView(...).

Previously, ViewManager.registerView() called
MeasurementDescriptorToViewMap.getView(...) followed by
MeasurementDescriptorToViewMap.putView(...) to insert a view only if it was not
present.  There was no locking, so the view could be created multiple times.
This commit refactors putView so that it covers the full transaction on the
underlying multimap.  It creates an empty MutableView if the view is not present
and inserts it into the multimap.

#### Use intrinsic locking in MeasurementDescriptorToViewMap.

MeasurementDescriptorToViewMap previously used a SynchronizedMultimap for
synchronization of its Multimap.  However, every method ended up needing to
access the Multimap within a synchronized block anyway, because the Multimap's
values were not synchronized.  It is simpler to just use a HashMultimap and
synchronize on the whole MeasurementDescriptorToViewMap object.