### PR TITLE
Add a class to represent a ViewDescriptor name.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/ViewDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ViewDescriptor.java
@@ -28,30 +28,24 @@ public abstract class ViewDescriptor {
   /**
    * Name of view. Must be unique.
    */
-  public final Name getViewDescriptorName() {
-    return name;
-  }
+  public abstract Name getViewDescriptorName();
 
   /**
    * Name of view, as a {@code String}.
    */
   public final String getName() {
-    return name.asString();
+    return getViewDescriptorName().asString();
   }
 
   /**
    * More detailed description, for documentation purposes.
    */
-  public final String getDescription() {
-    return description;
-  }
+  public abstract String getDescription();
 
   /**
    * Measurement type of this view.
    */
-  public final MeasurementDescriptor getMeasurementDescriptor() {
-    return measurementDescriptor;
-  }
+  public abstract MeasurementDescriptor getMeasurementDescriptor();
 
   /**
    * Tag keys to match with the associated {@link MeasurementDescriptor}. If no keys are specified,
@@ -60,9 +54,7 @@ public abstract class ViewDescriptor {
    * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
    * UnsupportedOperationException.
    */
-  public final List<TagKey> getTagKeys() {
-    return tagKeys;
-  }
+  public abstract List<TagKey> getTagKeys();
 
   /**
    * Applies the given match function to the underlying data type.
@@ -70,23 +62,6 @@ public abstract class ViewDescriptor {
   public abstract <T> T match(
       Function<DistributionViewDescriptor, T> p0,
       Function<IntervalViewDescriptor, T> p1);
-
-
-  private final Name name;
-  private final String description;
-  private final MeasurementDescriptor measurementDescriptor;
-  private final List<TagKey> tagKeys;
-
-  private ViewDescriptor(
-      Name name,
-      String description,
-      MeasurementDescriptor measurementDescriptor,
-      List<TagKey> tagKeys) {
-    this.name = name;
-    this.description = description;
-    this.measurementDescriptor = measurementDescriptor;
-    this.tagKeys = Collections.unmodifiableList(new ArrayList<TagKey>(tagKeys));
-  }
 
   /**
    * The name of a {@code ViewDescriptor}.
@@ -118,7 +93,8 @@ public abstract class ViewDescriptor {
   /**
    * A {@link ViewDescriptor} for distribution-base aggregations.
    */
-  public static class DistributionViewDescriptor extends ViewDescriptor {
+  @AutoValue
+  public abstract static class DistributionViewDescriptor extends ViewDescriptor {
     /**
      * Constructs a new {@link DistributionViewDescriptor}.
      */
@@ -128,7 +104,7 @@ public abstract class ViewDescriptor {
         MeasurementDescriptor measurementDescriptor,
         DistributionAggregationDescriptor distributionAggregationDescriptor,
         List<TagKey> tagKeys) {
-      return new DistributionViewDescriptor(
+      return create(
           Name.create(name),
           description,
           measurementDescriptor,
@@ -145,17 +121,19 @@ public abstract class ViewDescriptor {
         MeasurementDescriptor measurementDescriptor,
         DistributionAggregationDescriptor distributionAggregationDescriptor,
         List<TagKey> tagKeys) {
-      return new DistributionViewDescriptor(
-          name, description, measurementDescriptor, distributionAggregationDescriptor, tagKeys);
+      return new AutoValue_ViewDescriptor_DistributionViewDescriptor(
+          name,
+          description,
+          measurementDescriptor,
+          Collections.unmodifiableList(new ArrayList<TagKey>(tagKeys)),
+          distributionAggregationDescriptor);
     }
 
     /**
      * The {@link DistributionAggregationDescriptor} associated with this
      * {@link DistributionViewDescriptor}.
      */
-    public DistributionAggregationDescriptor getDistributionAggregationDescriptor() {
-      return distributionAggregationDescriptor;
-    }
+    public abstract DistributionAggregationDescriptor getDistributionAggregationDescriptor();
 
     @Override
     public <T> T match(
@@ -163,24 +141,13 @@ public abstract class ViewDescriptor {
         Function<IntervalViewDescriptor, T> p1) {
       return p0.apply(this);
     }
-
-    private final DistributionAggregationDescriptor distributionAggregationDescriptor;
-
-    private DistributionViewDescriptor(
-        Name name,
-        String description,
-        MeasurementDescriptor measurementDescriptor,
-        DistributionAggregationDescriptor distributionAggregationDescriptor,
-        List<TagKey> tagKeys) {
-      super(name, description, measurementDescriptor, tagKeys);
-      this.distributionAggregationDescriptor = distributionAggregationDescriptor;
-    }
   }
 
   /**
    * A {@link ViewDescriptor} for interval-based aggregations.
    */
-  public static class IntervalViewDescriptor extends ViewDescriptor {
+  @AutoValue
+  public abstract static class IntervalViewDescriptor extends ViewDescriptor {
     /**
      * Constructs a new {@link IntervalViewDescriptor}.
      */
@@ -190,7 +157,7 @@ public abstract class ViewDescriptor {
         MeasurementDescriptor measurementDescriptor,
         IntervalAggregationDescriptor intervalAggregationDescriptor,
         List<TagKey> tagKeys) {
-      return new IntervalViewDescriptor(
+      return create(
           Name.create(name),
           description,
           measurementDescriptor,
@@ -207,35 +174,25 @@ public abstract class ViewDescriptor {
         MeasurementDescriptor measurementDescriptor,
         IntervalAggregationDescriptor intervalAggregationDescriptor,
         List<TagKey> tagKeys) {
-      return new IntervalViewDescriptor(
-          name, description, measurementDescriptor, intervalAggregationDescriptor, tagKeys);
+      return new AutoValue_ViewDescriptor_IntervalViewDescriptor(
+          name,
+          description,
+          measurementDescriptor,
+          Collections.unmodifiableList(new ArrayList<TagKey>(tagKeys)),
+          intervalAggregationDescriptor);
     }
 
     /**
      * The {@link IntervalAggregationDescriptor} associated with this
      * {@link IntervalViewDescriptor}.
      */
-    public IntervalAggregationDescriptor getIntervalAggregationDescriptor() {
-      return intervalAggregationDescriptor;
-    }
+    public abstract IntervalAggregationDescriptor getIntervalAggregationDescriptor();
 
     @Override
     public <T> T match(
         Function<DistributionViewDescriptor, T> p0,
         Function<IntervalViewDescriptor, T> p1) {
       return p1.apply(this);
-    }
-
-    private final IntervalAggregationDescriptor intervalAggregationDescriptor;
-
-    private IntervalViewDescriptor(
-        Name name,
-        String description,
-        MeasurementDescriptor measurementDescriptor,
-        IntervalAggregationDescriptor intervalAggregationDescriptor,
-        List<TagKey> tagKeys) {
-      super(name, description, measurementDescriptor, tagKeys);
-      this.intervalAggregationDescriptor = intervalAggregationDescriptor;
     }
   }
 }

--- a/core/src/main/java/com/google/instrumentation/stats/ViewDescriptor.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ViewDescriptor.java
@@ -13,6 +13,7 @@
 
 package com.google.instrumentation.stats;
 
+import com.google.auto.value.AutoValue;
 import com.google.instrumentation.common.Function;
 
 import java.util.ArrayList;
@@ -27,8 +28,15 @@ public abstract class ViewDescriptor {
   /**
    * Name of view. Must be unique.
    */
-  public final String getName() {
+  public final Name getViewDescriptorName() {
     return name;
+  }
+
+  /**
+   * Name of view, as a {@code String}.
+   */
+  public final String getName() {
+    return name.asString();
   }
 
   /**
@@ -64,13 +72,13 @@ public abstract class ViewDescriptor {
       Function<IntervalViewDescriptor, T> p1);
 
 
-  private final String name;
+  private final Name name;
   private final String description;
   private final MeasurementDescriptor measurementDescriptor;
   private final List<TagKey> tagKeys;
 
   private ViewDescriptor(
-      String name,
+      Name name,
       String description,
       MeasurementDescriptor measurementDescriptor,
       List<TagKey> tagKeys) {
@@ -78,6 +86,33 @@ public abstract class ViewDescriptor {
     this.description = description;
     this.measurementDescriptor = measurementDescriptor;
     this.tagKeys = Collections.unmodifiableList(new ArrayList<TagKey>(tagKeys));
+  }
+
+  /**
+   * The name of a {@code ViewDescriptor}.
+   */
+  // This type should be used as the key when associating data with ViewDescriptors.
+  @AutoValue
+  public abstract static class Name {
+
+    Name() {}
+
+    /**
+     * Returns the name as a {@code String}.
+     *
+     * @return the name as a {@code String}.
+     */
+    public abstract String asString();
+
+    /**
+     * Creates a {@code ViewDescriptor.Name} from a {@code String}.
+     *
+     * @param name the name {@code String}.
+     * @return a {@code ViewDescriptor.Name} with the given name {@code String}.
+     */
+    public static Name create(String name) {
+      return new AutoValue_ViewDescriptor_Name(name);
+    }
   }
 
   /**
@@ -89,6 +124,23 @@ public abstract class ViewDescriptor {
      */
     public static DistributionViewDescriptor create(
         String name,
+        String description,
+        MeasurementDescriptor measurementDescriptor,
+        DistributionAggregationDescriptor distributionAggregationDescriptor,
+        List<TagKey> tagKeys) {
+      return new DistributionViewDescriptor(
+          Name.create(name),
+          description,
+          measurementDescriptor,
+          distributionAggregationDescriptor,
+          tagKeys);
+    }
+
+    /**
+     * Constructs a new {@link DistributionViewDescriptor}.
+     */
+    public static DistributionViewDescriptor create(
+        Name name,
         String description,
         MeasurementDescriptor measurementDescriptor,
         DistributionAggregationDescriptor distributionAggregationDescriptor,
@@ -115,7 +167,7 @@ public abstract class ViewDescriptor {
     private final DistributionAggregationDescriptor distributionAggregationDescriptor;
 
     private DistributionViewDescriptor(
-        String name,
+        Name name,
         String description,
         MeasurementDescriptor measurementDescriptor,
         DistributionAggregationDescriptor distributionAggregationDescriptor,
@@ -134,6 +186,23 @@ public abstract class ViewDescriptor {
      */
     public static IntervalViewDescriptor create(
         String name,
+        String description,
+        MeasurementDescriptor measurementDescriptor,
+        IntervalAggregationDescriptor intervalAggregationDescriptor,
+        List<TagKey> tagKeys) {
+      return new IntervalViewDescriptor(
+          Name.create(name),
+          description,
+          measurementDescriptor,
+          intervalAggregationDescriptor,
+          tagKeys);
+    }
+
+    /**
+     * Constructs a new {@link IntervalViewDescriptor}.
+     */
+    public static IntervalViewDescriptor create(
+        Name name,
         String description,
         MeasurementDescriptor measurementDescriptor,
         IntervalAggregationDescriptor intervalAggregationDescriptor,
@@ -160,7 +229,7 @@ public abstract class ViewDescriptor {
     private final IntervalAggregationDescriptor intervalAggregationDescriptor;
 
     private IntervalViewDescriptor(
-        String name,
+        Name name,
         String description,
         MeasurementDescriptor measurementDescriptor,
         IntervalAggregationDescriptor intervalAggregationDescriptor,

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -116,6 +116,46 @@ public final class ViewDescriptorTest {
         .testEquals();
   }
 
+  @Test(expected = NullPointerException.class)
+  public void preventNullDistributionViewDescriptorName() {
+    DistributionViewDescriptor.create(
+        (ViewDescriptor.Name) null,
+        description,
+        measurementDescriptor,
+        DistributionAggregationDescriptor.create(),
+        keys);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void preventNullDistributionViewDescriptorStringName() {
+    DistributionViewDescriptor.create(
+        (String) null,
+        description,
+        measurementDescriptor,
+        DistributionAggregationDescriptor.create(),
+        keys);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void preventNullIntervalViewDescriptorName() {
+    IntervalViewDescriptor.create(
+        (ViewDescriptor.Name) null,
+        description,
+        measurementDescriptor,
+        IntervalAggregationDescriptor.create(Arrays.asList(Duration.fromMillis(1))),
+        keys);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void preventNullIntervalViewDescriptorStringName() {
+    IntervalViewDescriptor.create(
+        (String) null,
+        description,
+        measurementDescriptor,
+        IntervalAggregationDescriptor.create(Arrays.asList(Duration.fromMillis(1))),
+        keys);
+  }
+
   @Test
   public void testViewDescriptorName() {
     assertThat(ViewDescriptor.Name.create("my name").asString()).isEqualTo("my name");

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -161,6 +161,11 @@ public final class ViewDescriptorTest {
     assertThat(ViewDescriptor.Name.create("my name").asString()).isEqualTo("my name");
   }
 
+  @Test(expected = NullPointerException.class)
+  public void preventNullNameString() {
+    ViewDescriptor.Name.create(null);
+  }
+
   @Test
   public void testViewDescriptorNameEquals() {
     new EqualsTester()

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -42,7 +42,8 @@ public final class ViewDescriptorTest {
     final ViewDescriptor viewDescriptor = DistributionViewDescriptor.create(
         name, description, measurementDescriptor, dAggrDescriptor, keys);
 
-    assertThat(viewDescriptor.getName()).isEqualTo(name);
+    assertThat(viewDescriptor.getViewDescriptorName()).isEqualTo(name);
+    assertThat(viewDescriptor.getName()).isEqualTo(name.asString());
     assertThat(viewDescriptor.getDescription()).isEqualTo(description);
     assertThat(viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName())
         .isEqualTo(measurementDescriptor.getMeasurementDescriptorName());
@@ -69,7 +70,8 @@ public final class ViewDescriptorTest {
     final ViewDescriptor viewDescriptor = IntervalViewDescriptor.create(
         name, description, measurementDescriptor, iAggrDescriptor, keys);
 
-    assertThat(viewDescriptor.getName()).isEqualTo(name);
+    assertThat(viewDescriptor.getViewDescriptorName()).isEqualTo(name);
+    assertThat(viewDescriptor.getName()).isEqualTo(name.asString());
     assertThat(viewDescriptor.getDescription()).isEqualTo(description);
     assertThat(viewDescriptor.getMeasurementDescriptor().getMeasurementDescriptorName())
         .isEqualTo(measurementDescriptor.getMeasurementDescriptorName());
@@ -103,7 +105,7 @@ public final class ViewDescriptorTest {
         .testEquals();
   }
 
-  private final String name = "test-view-name";
+  private final ViewDescriptor.Name name = ViewDescriptor.Name.create("test-view-name");
   private final String description = "test-view-name description";
   private final MeasurementDescriptor measurementDescriptor = MeasurementDescriptor.create(
       "measurement",

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -92,6 +92,31 @@ public final class ViewDescriptorTest {
   }
 
   @Test
+  public void testViewDescriptorEquals() {
+    DistributionAggregationDescriptor dAggrDescriptor = DistributionAggregationDescriptor.create();
+    IntervalAggregationDescriptor iAggrDescriptor = IntervalAggregationDescriptor.create(
+        Arrays.asList(Duration.fromMillis(1), Duration.fromMillis(22), Duration.fromMillis(333)));
+    new EqualsTester()
+        .addEqualityGroup(
+            DistributionViewDescriptor.create(
+                name, description, measurementDescriptor, dAggrDescriptor, keys),
+            DistributionViewDescriptor.create(
+                name, description, measurementDescriptor, dAggrDescriptor, keys))
+        .addEqualityGroup(
+            DistributionViewDescriptor.create(
+                name, description + 2, measurementDescriptor, dAggrDescriptor, keys))
+        .addEqualityGroup(
+            IntervalViewDescriptor.create(
+                name, description, measurementDescriptor, iAggrDescriptor, keys),
+            IntervalViewDescriptor.create(
+                name, description, measurementDescriptor, iAggrDescriptor, keys))
+        .addEqualityGroup(
+            IntervalViewDescriptor.create(
+                name, description + 2, measurementDescriptor, iAggrDescriptor, keys))
+        .testEquals();
+  }
+
+  @Test
   public void testViewDescriptorName() {
     assertThat(ViewDescriptor.Name.create("my name").asString()).isEqualTo("my name");
   }

--- a/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ViewDescriptorTest.java
@@ -17,6 +17,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.testing.EqualsTester;
 import com.google.instrumentation.common.Duration;
 import com.google.instrumentation.common.Function;
 import com.google.instrumentation.stats.MeasurementDescriptor.BasicUnit;
@@ -86,6 +87,20 @@ public final class ViewDescriptorTest {
             return iViewDescriptor == viewDescriptor;
           }
         }));
+  }
+
+  @Test
+  public void testViewDescriptorName() {
+    assertThat(ViewDescriptor.Name.create("my name").asString()).isEqualTo("my name");
+  }
+
+  @Test
+  public void testViewDescriptorNameEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            ViewDescriptor.Name.create("view-1"), ViewDescriptor.Name.create("view-1"))
+        .addEqualityGroup(ViewDescriptor.Name.create("view-2"))
+        .testEquals();
   }
 
   private final String name = "test-view-name";

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -72,7 +72,6 @@ final class MeasurementDescriptorToViewMap {
   synchronized void registerView(ViewDescriptor viewDescriptor, Clock clock) {
     ViewDescriptor existing = registeredViews.get(viewDescriptor.getViewDescriptorName());
     if (existing != null) {
-      // TODO(sebright): Override equals(...) in ViewDescriptor.
       if (existing.equals(viewDescriptor)) {
         // Ignore views that are already registered.
         return;

--- a/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMap.java
@@ -64,8 +64,8 @@ final class MeasurementDescriptorToViewMap {
         return view;
       }
     }
-    throw new AssertionError("registeredViews and mutableMap contain different views: "
-        + "registeredViews=" + registeredViews + ", mutableMap=" + mutableMap);
+    throw new AssertionError("Internal error: Not recording stats for view: \"" + viewName
+        + "\" registeredViews=" + registeredViews + ", mutableMap=" + mutableMap);
   }
 
   /** Enable stats collection for the given {@link ViewDescriptor}. */

--- a/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImplBase.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/StatsManagerImplBase.java
@@ -38,9 +38,10 @@ class StatsManagerImplBase extends StatsManager {
     viewManager.registerView(viewDescriptor);
   }
 
+  // TODO(sebright): This method should take a ViewDescriptor.Name.
   @Override
   public View getView(ViewDescriptor viewDescriptor) {
-    return viewManager.getView(viewDescriptor);
+    return viewManager.getView(viewDescriptor.getViewDescriptorName());
   }
 
   @Override

--- a/core_impl/src/main/java/com/google/instrumentation/stats/ViewManager.java
+++ b/core_impl/src/main/java/com/google/instrumentation/stats/ViewManager.java
@@ -45,11 +45,11 @@ final class ViewManager {
     measurementDescriptorToViewMap.registerView(viewDescriptor, clock);
   }
 
-  View getView(ViewDescriptor viewDescriptor) {
-    View view = measurementDescriptorToViewMap.getView(viewDescriptor, clock);
+  View getView(ViewDescriptor.Name viewName) {
+    View view = measurementDescriptorToViewMap.getView(viewName, clock);
     if (view == null) {
       throw new IllegalArgumentException(
-          "View for view descriptor " + viewDescriptor.getName() + " not found.");
+          "View for view descriptor " + viewName + " not found.");
     } else {
       return view;
     }

--- a/core_impl/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMapTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/MeasurementDescriptorToViewMapTest.java
@@ -38,7 +38,9 @@ public class MeasurementDescriptorToViewMapTest {
     measurementDescriptorToViewMap.registerView(
         RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW, clock);
     clock.setTime(Timestamp.create(30, 40));
-    View actual = measurementDescriptorToViewMap.getView(RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW, clock);
+    View actual =
+        measurementDescriptorToViewMap.getView(
+            RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW.getViewDescriptorName(), clock);
     actual.match(
         new Function<View.DistributionView, Void>() {
           @Override

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsManagerImplTest.java
@@ -20,11 +20,13 @@ import com.google.instrumentation.common.SimpleEventQueue;
 import com.google.instrumentation.common.Timestamp;
 import com.google.instrumentation.internal.TestClock;
 import com.google.instrumentation.stats.View.DistributionView;
+import com.google.instrumentation.stats.ViewDescriptor.DistributionViewDescriptor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -80,6 +82,23 @@ public class StatsManagerImplTest {
     View actual = statsManager.getView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
     assertThat(actual.getViewDescriptor()).isEqualTo(
         RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+  }
+
+  // TODO(sebright) Enable this test once we support more than one view.
+  @Ignore
+  @Test
+  public void preventRegisteringDifferentViewDescriptorWithSameName() {
+    statsManager.registerView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+    ViewDescriptor view2 =
+      DistributionViewDescriptor.create(
+          "grpc.io/client/roundtrip_latency/distribution_cumulative",
+          "This is a different description.",
+          RpcMeasurementConstants.RPC_CLIENT_ROUNDTRIP_LATENCY,
+          DistributionAggregationDescriptor.create(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES),
+          Arrays.asList(RpcMeasurementConstants.RPC_CLIENT_METHOD));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("A different view with the same name is already registered");
+    statsManager.registerView(view2);
   }
 
   @Test


### PR DESCRIPTION
This class can be used to query Views, since ViewDescriptor names must be
unique. This commit also prevents a view from being registered if it has the
same name as an existing view but is not the same view.

/cc @dinooliva @bogdandrutu @a-veitch 