### PR TITLE
Add benchmarks for start/end span and record trace events.

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -32,5 +32,14 @@ compileJmhJava {
     options.compilerArgs = compileJava.options.compilerArgs
 }
 
+
+// Generate html report for findbugsJmh.
+findbugsJmh {
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+}
+
 // Disable checkstyle if not java8.
 checkstyleJmh.enabled = JavaVersion.current().isJava8Compatible()

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -14,7 +14,6 @@
 package com.google.instrumentation.trace;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -44,7 +43,7 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
     linkedSpan.end();
   }
 
-  /** This benchmark attempts to measure performance of {@link Span#addAttributes(Map)}. */
+  /** This benchmark attempts to measure performance of adding an attribute to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -55,7 +54,7 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
     return span;
   }
 
-  /** This benchmark attempts to measure performance of {@link Span#addAnnotation(String)}. */
+  /** This benchmark attempts to measure performance of adding an annotation to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -64,9 +63,7 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
     return span;
   }
 
-  /**
-   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
-   */
+  /** This benchmark attempts to measure performance of adding a network event to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -75,9 +72,7 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
     return span;
   }
 
-  /**
-   * This benchmark attempts to measure performance of {@link Span#addLink(Link)}.
-   */
+  /** This benchmark attempts to measure performance of adding a link to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/** Benchmarks for {@link SpanImpl} to record trace events. */
+@State(Scope.Benchmark)
+public class RecordTraceEventsNonSampledSpanBenchmark {
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final String SPAN_NAME = "MySpanName";
+  private static final String ANNOTATION_DESCRIPTION = "MyAnnotation";
+  private static final String ATTRIBUTE_KEY = "MyAttributeKey";
+  private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
+  private Span linkedSpan =
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+  private Span span =
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+
+  /** TearDown method. */
+  @TearDown
+  public void doTearDown() {
+    span.end();
+    linkedSpan.end();
+  }
+
+  /** This benchmark attempts to measure performance of {@link Span#addAttributes(Map)}. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addAttributes() {
+    HashMap<String, AttributeValue> attributes = new HashMap<String, AttributeValue>();
+    attributes.put(ATTRIBUTE_KEY, AttributeValue.stringAttributeValue(ATTRIBUTE_VALUE));
+    span.addAttributes(attributes);
+    return span;
+  }
+
+  /** This benchmark attempts to measure performance of {@link Span#addAnnotation(String)}. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addAnnotation() {
+    span.addAnnotation(ANNOTATION_DESCRIPTION);
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addNetworkEvent() {
+    span.addNetworkEvent(NetworkEvent.builder(NetworkEvent.Type.RECV, 1).setMessageSize(3).build());
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addLink() {
+    span.addLink(Link.fromSpanContext(linkedSpan.getContext(), Link.Type.PARENT));
+    return span;
+  }
+}

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -33,9 +33,9 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.neverSample()).startSpan();
   private Span span =
-      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.neverSample()).startSpan();
 
   /** TearDown method. */
   @TearDown
@@ -76,7 +76,7 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
   }
 
   /**
-   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   * This benchmark attempts to measure performance of {@link Span#addLink(Link)}.
    */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/** Benchmarks for {@link SpanImpl} to record trace events. */
+@State(Scope.Benchmark)
+public class RecordTraceEventsSampledSpanBenchmark {
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final String SPAN_NAME = "MySpanName";
+  private static final String ANNOTATION_DESCRIPTION = "MyAnnotation";
+  private static final String ATTRIBUTE_KEY = "MyAttributeKey";
+  private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
+  private Span linkedSpan =
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+  private Span span =
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.alwaysSample()).startSpan();
+
+  /** TearDown method. */
+  @TearDown
+  public void doTearDown() {
+    span.end();
+    linkedSpan.end();
+  }
+
+  /** This benchmark attempts to measure performance of {@link Span#addAttributes(Map)}. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addAttributes() {
+    HashMap<String, AttributeValue> attributes = new HashMap<String, AttributeValue>();
+    attributes.put(ATTRIBUTE_KEY, AttributeValue.stringAttributeValue(ATTRIBUTE_VALUE));
+    span.addAttributes(attributes);
+    return span;
+  }
+
+  /** This benchmark attempts to measure performance of {@link Span#addAnnotation(String)}. */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addAnnotation() {
+    span.addAnnotation(ANNOTATION_DESCRIPTION);
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addNetworkEvent() {
+    span.addNetworkEvent(NetworkEvent.builder(NetworkEvent.Type.RECV, 1).setMessageSize(3).build());
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span addLink() {
+    span.addLink(Link.fromSpanContext(linkedSpan.getContext(), Link.Type.PARENT));
+    return span;
+  }
+}

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -76,7 +76,7 @@ public class RecordTraceEventsSampledSpanBenchmark {
   }
 
   /**
-   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
+   * This benchmark attempts to measure performance of {@link Span#addLink(Link)}.
    */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -14,7 +14,6 @@
 package com.google.instrumentation.trace;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -44,7 +43,7 @@ public class RecordTraceEventsSampledSpanBenchmark {
     linkedSpan.end();
   }
 
-  /** This benchmark attempts to measure performance of {@link Span#addAttributes(Map)}. */
+  /** This benchmark attempts to measure performance of adding an attribute to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -55,7 +54,7 @@ public class RecordTraceEventsSampledSpanBenchmark {
     return span;
   }
 
-  /** This benchmark attempts to measure performance of {@link Span#addAnnotation(String)}. */
+  /** This benchmark attempts to measure performance of adding an annotation to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -64,9 +63,7 @@ public class RecordTraceEventsSampledSpanBenchmark {
     return span;
   }
 
-  /**
-   * This benchmark attempts to measure performance of {@link Span#addNetworkEvent(NetworkEvent)}.
-   */
+  /** This benchmark attempts to measure performance of adding a network event to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -75,9 +72,7 @@ public class RecordTraceEventsSampledSpanBenchmark {
     return span;
   }
 
-  /**
-   * This benchmark attempts to measure performance of {@link Span#addLink(Link)}.
-   */
+  /** This benchmark attempts to measure performance of adding a link to the span. */
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/benchmarks/src/jmh/java/com/google/instrumentation/trace/StartEndSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/com/google/instrumentation/trace/StartEndSpanBenchmark.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/** Benchmarks for {@link SpanFactoryImpl} and {@link SpanImpl}. */
+@State(Scope.Benchmark)
+public class StartEndSpanBenchmark {
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final String SPAN_NAME = "MySpanName";
+  private Span rootSpan =
+      tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.neverSample()).startSpan();
+
+  @TearDown
+  public void doTearDown() {
+    rootSpan.end();
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a non-sampled root {@code
+   * Span}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndNonSampledRootSpan() {
+    Span span =
+        tracer.spanBuilder(SPAN_NAME).becomeRoot().setSampler(Samplers.neverSample()).startSpan();
+    span.end();
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a root {@code Span} with record
+   * events option.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndRecordEventsRootSpan() {
+    Span span =
+        tracer
+            .spanBuilder(SPAN_NAME)
+            .becomeRoot()
+            .setSampler(Samplers.neverSample())
+            .setRecordEvents(true)
+            .startSpan();
+    span.end();
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a sampled root {@code Span}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndSampledRootSpan() {
+    Span span = tracer.spanBuilder(SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+    span.end();
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a non-sampled child {@code
+   * Span}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndNonSampledChildSpan() {
+    Span span =
+        tracer.spanBuilder(rootSpan, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+    span.end();
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a child {@code Span} with
+   * record events option.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndRecordEventsChildSpan() {
+    Span span =
+        tracer
+            .spanBuilder(rootSpan, SPAN_NAME)
+            .setSampler(Samplers.neverSample())
+            .setRecordEvents(true)
+            .startSpan();
+    span.end();
+    return span;
+  }
+
+  /**
+   * This benchmark attempts to measure performance of start/end for a sampled child {@code Span}.
+   */
+  @Benchmark
+  @BenchmarkMode(Mode.SampleTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public Span startEndSampledChildSpan() {
+    Span span =
+        tracer.spanBuilder(rootSpan, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+    span.end();
+    return span;
+  }
+}


### PR DESCRIPTION
Benchmarks ran with https://github.com/google/instrumentation-java/pull/296 (mean values)

BinaryPropagationHandlerImplBenchmark.fromBinaryValueSpanContext      66.611 ±  1.568  ns/op
BinaryPropagationHandlerImplBenchmark.toBinaryValueSpanContext          67.977 ±  2.524  ns/op
BinaryPropagationHandlerImplBenchmark.toFromBinarySpanContext           146.850 ± 39.152  ns/op
RecordTraceEventsNonSampledSpanBenchmark.addAnnotation                  55.014 ±  1.872  ns/op
RecordTraceEventsNonSampledSpanBenchmark.addLink                             46.806 ±  1.752  ns/op
RecordTraceEventsNonSampledSpanBenchmark.addNetworkEvent             49.202 ±  1.996  ns/op
RecordTraceEventsSampledSpanBenchmark.addAnnotation                         79.445 ± 40.390  ns/op
RecordTraceEventsSampledSpanBenchmark.addLink                                    59.594 ± 17.770  ns/op
RecordTraceEventsSampledSpanBenchmark.addNetworkEvent                    48.520 ±  1.840  ns/op
StartEndSpanBenchmark.startEndNonSampledChildSpan                             68.181 ±  8.417  ns/op
StartEndSpanBenchmark.startEndNonSampledRootSpan                              69.895 ±  3.243  ns/op
StartEndSpanBenchmark.startEndRecordEventsChildSpan                            61.785 ± 24.352  ns/op
StartEndSpanBenchmark.startEndRecordEventsRootSpan                             58.410 ±  3.025  ns/op
StartEndSpanBenchmark.startEndSampledChildSpan                                     61.010 ± 12.419  ns/op
StartEndSpanBenchmark.startEndSampledRootSpan                                      61.113 ±  3.164  ns/op