### PR TITLE
Implement minimal functionality for StatsContext to interact with gRPC Context.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+import com.google.instrumentation.common.NonThrowingCloseable;
+import io.grpc.Context;
+
+/**
+ * Util methods/functionality to interact with the {@link io.grpc.Context}.
+ *
+ * <p>Users must interact with the current Context via the public APIs in {@link
+ * StatsContextFactory} and avoid usages of the {@link #STATS_CONTEXT_KEY} directly.
+ */
+public final class ContextUtils {
+
+  /**
+   * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
+   */
+  public static final Context.Key<StatsContext> STATS_CONTEXT_KEY = Context.key(
+      "instrumentation-stats-key");
+
+  // Static class.
+  private ContextUtils() {
+  }
+
+  /**
+   * Returns The {@link StatsContext} from the current context.
+   *
+   * @return The {@code StatsContext} from the current context.
+   */
+  static StatsContext getCurrentStatsContext() {
+    return STATS_CONTEXT_KEY.get(Context.current());
+  }
+
+  /**
+   * Construct a new {@link Context} where the given {@link StatsContext} is set, with current
+   * context as its parent.
+   *
+   * @param statsContext The {@code StatsContext} to be set to the current context.
+   * @return a new context where the given {@code StatsContext}, and its parent is current context.
+   */
+  static Context withStatsContext(StatsContext statsContext) {
+    return Context.current().withValue(STATS_CONTEXT_KEY, statsContext);
+  }
+
+  /**
+   * Enters the scope of code where the given {@link StatsContext} is in the current context, and
+   * returns an object that represents that scope. The scope is exited when the returned object
+   * is closed.
+   *
+   * <p>Supports try-with-resource idiom.
+   *
+   * @param statsContext The {@code StatsContext} to be set to the current context.
+   * @return An object that defines a scope where the given {@code StatsContext} is set to the
+   *     current context.
+   */
+  static NonThrowingCloseable withScopedStatsContext(StatsContext statsContext) {
+    return new WithStatsContext(statsContext, STATS_CONTEXT_KEY);
+  }
+
+  // Supports try-with-resources idiom.
+  private static final class WithStatsContext implements NonThrowingCloseable {
+
+    private final Context origContext;
+
+    /**
+     * Constructs a new {@link WithStatsContext}.
+     *
+     * @param statsContext is the {@code StatsContext} to be added to the current {@code Context}.
+     * @param contextKey is the {@code Context.Key} used to set/get {@code StatsContext} from the
+     * {@code Context}.
+     */
+    WithStatsContext(StatsContext statsContext, Context.Key<StatsContext> contextKey) {
+      origContext = Context.current().withValue(contextKey, statsContext).attach();
+    }
+
+    @Override
+    public void close() {
+      Context.current().detach(origContext);
+    }
+  }
+}

--- a/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
@@ -71,7 +71,7 @@ public final class ContextUtils {
      * @param contextKey is the {@code Context.Key} used to set/get {@code StatsContext} from the
      * {@code Context}.
      */
-    WithStatsContext(StatsContext statsContext, Context.Key<StatsContext> contextKey) {
+    private WithStatsContext(StatsContext statsContext, Context.Key<StatsContext> contextKey) {
       origContext = Context.current().withValue(contextKey, statsContext).attach();
     }
 

--- a/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
@@ -44,17 +44,6 @@ public final class ContextUtils {
   }
 
   /**
-   * Construct a new {@link Context} where the given {@link StatsContext} is set, with current
-   * context as its parent.
-   *
-   * @param statsContext The {@code StatsContext} to be set to the current context.
-   * @return a new context where the given {@code StatsContext}, and its parent is current context.
-   */
-  static Context withStatsContext(StatsContext statsContext) {
-    return Context.current().withValue(STATS_CONTEXT_KEY, statsContext);
-  }
-
-  /**
    * Enters the scope of code where the given {@link StatsContext} is in the current context, and
    * returns an object that represents that scope. The scope is exited when the returned object
    * is closed.
@@ -65,7 +54,7 @@ public final class ContextUtils {
    * @return An object that defines a scope where the given {@code StatsContext} is set to the
    *     current context.
    */
-  static NonThrowingCloseable withScopedStatsContext(StatsContext statsContext) {
+  static NonThrowingCloseable withStatsContext(StatsContext statsContext) {
     return new WithStatsContext(statsContext, STATS_CONTEXT_KEY);
   }
 

--- a/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
+++ b/core/src/main/java/com/google/instrumentation/stats/ContextUtils.java
@@ -27,6 +27,7 @@ public final class ContextUtils {
   /**
    * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
    */
+  // TODO(songya): Discourage the usage of STATS_CONTEXT_KEY for normal users if needed.
   public static final Context.Key<StatsContext> STATS_CONTEXT_KEY = Context.key(
       "instrumentation-stats-key");
 

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContext.java
@@ -15,10 +15,12 @@ package com.google.instrumentation.stats;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * An immutable context for stats operations.
  */
+@Immutable
 public abstract class StatsContext {
   /**
    * Returns a builder based on this {@link StatsContext}.

--- a/core/src/test/java/com/google/instrumentation/stats/ContextUtilsTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ContextUtilsTest.java
@@ -44,51 +44,9 @@ public class ContextUtilsTest {
   }
 
   @Test
-  public void testWithAndGetStatsContext() {
+  public void testWithStatsContext() {
     assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-    Context origContext = ContextUtils.withStatsContext(statsContext).attach();
-    // Make sure context is detached even if test fails.
-    try {
-      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
-    } finally {
-      Context.current().detach(origContext);
-    }
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-  }
-
-  @Test
-  public void testWithStatsContextUsingRun() {
-    Context context = ContextUtils.withStatsContext(statsContext);
-    // Run the Runnable immediately.
-    context.run(new Runnable() {
-      @Override
-      public void run() {
-        assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
-      }
-    });
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-  }
-
-  @Test
-  public void testWithStatsContextUsingWrap() {
-    Context context = ContextUtils.withStatsContext(statsContext);
-    // Wrap a Runnable and run it later.
-    Runnable runnable = context.wrap(
-        new Runnable() {
-          @Override
-          public void run() {
-            assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
-          }
-        });
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-    // When we run the runnable we will have the statsContext in the current Context.
-    runnable.run();
-  }
-
-  @Test
-  public void testWithScopedStatsContext() {
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-    NonThrowingCloseable scopedStatsCtx = ContextUtils.withScopedStatsContext(statsContext);
+    NonThrowingCloseable scopedStatsCtx = ContextUtils.withStatsContext(statsContext);
     try {
       assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
     } finally {
@@ -98,9 +56,9 @@ public class ContextUtilsTest {
   }
 
   @Test
-  public void testWithScopedStatsContextUsingWrap() {
+  public void testWithStatsContextUsingWrap() {
     Runnable runnable;
-    NonThrowingCloseable scopedStatsCtx = ContextUtils.withScopedStatsContext(statsContext);
+    NonThrowingCloseable scopedStatsCtx = ContextUtils.withStatsContext(statsContext);
     try {
       assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
       runnable = Context.current().wrap(

--- a/core/src/test/java/com/google/instrumentation/stats/ContextUtilsTest.java
+++ b/core/src/test/java/com/google/instrumentation/stats/ContextUtilsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.instrumentation.common.NonThrowingCloseable;
+import io.grpc.Context;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Unit tests for {@link ContextUtils}.
+ */
+@RunWith(JUnit4.class)
+public class ContextUtilsTest {
+
+  @Mock
+  private StatsContext statsContext;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testGetCurrentStatsContext_WhenNoContext() {
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testWithAndGetStatsContext() {
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    Context origContext = ContextUtils.withStatsContext(statsContext).attach();
+    // Make sure context is detached even if test fails.
+    try {
+      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+    } finally {
+      Context.current().detach(origContext);
+    }
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testWithStatsContextUsingRun() {
+    Context context = ContextUtils.withStatsContext(statsContext);
+    // Run the Runnable immediately.
+    context.run(new Runnable() {
+      @Override
+      public void run() {
+        assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+      }
+    });
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testWithStatsContextUsingWrap() {
+    Context context = ContextUtils.withStatsContext(statsContext);
+    // Wrap a Runnable and run it later.
+    Runnable runnable = context.wrap(
+        new Runnable() {
+          @Override
+          public void run() {
+            assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+          }
+        });
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    // When we run the runnable we will have the statsContext in the current Context.
+    runnable.run();
+  }
+
+  @Test
+  public void testWithScopedStatsContext() {
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    NonThrowingCloseable scopedStatsCtx = ContextUtils.withScopedStatsContext(statsContext);
+    try {
+      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+    } finally {
+      scopedStatsCtx.close();
+    }
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testWithScopedStatsContextUsingWrap() {
+    Runnable runnable;
+    NonThrowingCloseable scopedStatsCtx = ContextUtils.withScopedStatsContext(statsContext);
+    try {
+      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+      runnable = Context.current().wrap(
+          new Runnable() {
+            @Override
+            public void run() {
+              assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+            }
+          });
+    } finally {
+      scopedStatsCtx.close();
+    }
+    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    // When we run the runnable we will have the statsContext in the current Context.
+    runnable.run();
+  }
+}


### PR DESCRIPTION
This class is similar to [trace/ContextUtils.java](https://github.com/google/instrumentation-java/blob/master/core/src/main/java/com/google/instrumentation/trace/ContextUtils.java), to provide minimal util methods for StatsContext to interact with gRPC Context.

I made all the util methods package-private, and I plan to expose them via new APIs in StatsContextFactory.

/cc @bogdandrutu @sebright 