### PR TITLE
Change examples to use the logging service exporter.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/trace/TraceExporter.java
+++ b/core/src/main/java/com/google/instrumentation/trace/TraceExporter.java
@@ -88,20 +88,32 @@ public abstract class TraceExporter {
    *   // ...
    * }
    * }</pre>
-   *
    */
   @ThreadSafe
   public static final class LoggingServiceHandler extends ServiceHandler {
     private static final Logger logger = Logger.getLogger(LoggingServiceHandler.class.getName());
+    private static final String SERVICE_NAME =
+        "com.google.instrumentation.trace.LoggingServiceHandler";
     private static final LoggingServiceHandler INSTANCE = new LoggingServiceHandler();
 
     /**
-     * Returns the instance of the {@code LoggingServiceHandler}.
+     * Registers the {@code LoggingServiceHandler} to the {@code TraceExporter}.
      *
-     * @return the instance of the {@code LoggingServiceHandler}.
+     * @param traceExporter the instance of the {@code TraceExporter} where this service is
+     *     registered.
      */
-    public static LoggingServiceHandler getInstance() {
-      return INSTANCE;
+    public static void registerService(TraceExporter traceExporter) {
+      traceExporter.registerServiceHandler(SERVICE_NAME, INSTANCE);
+    }
+
+    /**
+     * Unregisters the {@code LoggingServiceHandler} from the {@code TraceExporter}.
+     *
+     * @param traceExporter the instance of the {@code TraceExporter} from where this service is
+     *     unregistered.
+     */
+    public static void unregisterService(TraceExporter traceExporter) {
+      traceExporter.unregisterServiceHandler(SERVICE_NAME);
     }
 
     @Override

--- a/core/src/test/java/com/google/instrumentation/trace/TraceExporterTest.java
+++ b/core/src/test/java/com/google/instrumentation/trace/TraceExporterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.instrumentation.trace;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.google.instrumentation.trace.TraceExporter.LoggingServiceHandler;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link TraceExporter}. */
+@RunWith(JUnit4.class)
+public class TraceExporterTest {
+  @Mock private TraceExporter traceExporter;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void registerUnregisterLoggingService() {
+    LoggingServiceHandler.registerService(traceExporter);
+    verify(traceExporter)
+        .registerServiceHandler(
+            eq("com.google.instrumentation.trace.LoggingServiceHandler"),
+            any(LoggingServiceHandler.class));
+    LoggingServiceHandler.unregisterService(traceExporter);
+    verify(traceExporter)
+        .unregisterServiceHandler(eq("com.google.instrumentation.trace.LoggingServiceHandler"));
+  }
+}

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansContextTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansContextTracing.java
@@ -15,6 +15,7 @@ package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
 import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.TraceExporter;
 import com.google.instrumentation.trace.Tracer;
 import com.google.instrumentation.trace.Tracing;
 
@@ -47,6 +48,7 @@ public final class MultiSpansContextTracing {
 
   /** Main method. */
   public static void main(String[] args) {
+    TraceExporter.LoggingServiceHandler.registerService(Tracing.getTraceExporter());
     Span span = tracer.spanBuilder("MyRootSpan").becomeRoot().startSpan();
     try (NonThrowingCloseable ws = tracer.withSpan(span)) {
       doWork();

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansScopedTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansScopedTracing.java
@@ -15,6 +15,7 @@ package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.common.NonThrowingCloseable;
 import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.TraceExporter;
 import com.google.instrumentation.trace.Tracer;
 import com.google.instrumentation.trace.Tracing;
 
@@ -45,6 +46,7 @@ public final class MultiSpansScopedTracing {
 
   /** Main method. */
   public static void main(String[] args) {
+    TraceExporter.LoggingServiceHandler.registerService(Tracing.getTraceExporter());
     try (NonThrowingCloseable ss =
         tracer.spanBuilder("MyRootSpan").becomeRoot().startScopedSpan()) {
       doWork();

--- a/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/com/google/instrumentation/examples/trace/MultiSpansTracing.java
@@ -14,6 +14,7 @@
 package com.google.instrumentation.examples.trace;
 
 import com.google.instrumentation.trace.Span;
+import com.google.instrumentation.trace.TraceExporter;
 import com.google.instrumentation.trace.Tracer;
 import com.google.instrumentation.trace.Tracing;
 
@@ -34,6 +35,7 @@ public final class MultiSpansTracing {
 
   /** Main method. */
   public static void main(String[] args) {
+    TraceExporter.LoggingServiceHandler.registerService(Tracing.getTraceExporter());
     doWork();
   }
 }


### PR DESCRIPTION
Change the interface of LoggingServiceHandler to enforce that maximum one instance is registered at any moment.