### PR TITLE
Add getCurrentStatsContext() and withStatsContext() API to StatsContextFactory.

### DIFF
--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.instrumentation.common.NonThrowingCloseable;
 import java.io.IOException;
 import java.io.InputStream;
-import javax.annotation.Nullable;
 
 /**
  * Factory class for {@link StatsContext}.
@@ -44,14 +43,13 @@ public abstract class StatsContextFactory {
   /**
    * Get current StatsContext from current gRPC Context.
    *
-   * @return the current {@code StatsContext} from {@code io.grpc.Context}, or {@code null} if
-   *     there's no {@code StatsContext} associated with current {@code io.grpc.Context}.
+   * @return the current {@code StatsContext} from {@code io.grpc.Context}, or the default
+   * {@code StatsContext} if there's no {@code StatsContext} associated with current
+   * {@code io.grpc.Context}.
    */
-  @Nullable
   public final StatsContext getCurrentStatsContext() {
-    // TODO(songya): return a no-op StatsContext (or default) when getCurrentStatsContext() returns
-    // null?
-    return ContextUtils.getCurrentStatsContext();
+    StatsContext statsContext = ContextUtils.getCurrentStatsContext();
+    return statsContext != null ? statsContext : getDefault();
   }
 
   /**
@@ -64,12 +62,11 @@ public abstract class StatsContextFactory {
    * <p>Example of usage:
    *
    * <pre>{@code
-   * // initialized by constructor or by calling Stats.getStatsContextFactory()
-   * private final StatsContextFactory statsCtxFactory;
-   * void doWork {
+   * private final StatsContextFactory statsCtxFactory = Stats.getStatsContextFactory();
+   * void doWork() {
    *   checkNotNull(statsCtxFactory, "statsCtxFactory");
    *   // Construct a new StatsContext with required tags to be set into current context.
-   *   StatsContext statsCtx = statsCtxFactory.getDefault().with(tagKey, tagValue);
+   *   StatsContext statsCtx = statsCtxFactory.getCurrentStatsContext().with(tagKey, tagValue);
    *   try (NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx)) {
    *     doSomeOtherWork();  // Here "scopedStatsCtx" is the current StatsContext.
    *   }
@@ -82,12 +79,11 @@ public abstract class StatsContextFactory {
    * <p>Example of usage prior to Java SE7:
    *
    * <pre>{@code
-   * // initialized by constructor or by calling Stats.getStatsContextFactory()
-   * private final StatsContextFactory statsCtxFactory;
-   * void doWork {
+   * private final StatsContextFactory statsCtxFactory = Stats.getStatsContextFactory();
+   * void doWork() {
    *   checkNotNull(statsCtxFactory, "statsCtxFactory");
    *   // Construct a new StatsContext with required tags to be set into current context.
-   *   StatsContext statsCtx = statsCtxFactory.getDefault().with(tagKey, tagValue);
+   *   StatsContext statsCtx = statsCtxFactory.getCurrentStatsContext().with(tagKey, tagValue);
    *   NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx);
    *   try {
    *     doSomeOtherWork();  // Here "scopedStatsCtx" is the current StatsContext.

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -13,13 +13,18 @@
 
 package com.google.instrumentation.stats;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.instrumentation.common.NonThrowingCloseable;
 import java.io.IOException;
 import java.io.InputStream;
+import javax.annotation.Nullable;
 
 /**
  * Factory class for {@link StatsContext}.
  */
 public abstract class StatsContextFactory {
+
   /**
    * Creates a {@link StatsContext} from the given on-the-wire encoded representation.
    *
@@ -35,4 +40,33 @@ public abstract class StatsContextFactory {
    * Returns the default {@link StatsContext}.
    */
   public abstract StatsContext getDefault();
+
+  /**
+   * Get current StatsContext from current gRPC Context.
+   *
+   * @return the current {@code StatsContext} from {@code io.grpc.Context}, or {@code null}
+   *     if there's no {@code StatsContext} associated with current {@code io.grpc.Context}.
+   */
+  @Nullable
+  public final StatsContext getCurrentStatsContext() {
+    // TODO(songya): return a no-op StatsContext (or default) when getCurrentStatsContext() returns
+    // null?
+    return ContextUtils.getCurrentStatsContext();
+  }
+
+  /**
+   * Enters the scope of code where the given {@link StatsContext} is in the current Context, and
+   * returns an object that represents that scope. The scope is exited when the returned object is
+   * closed.
+   *
+   * <p>Supports try-with-resource idiom.
+   *
+   * @param statsContext The {@link StatsContext} to be set to the current Context.
+   * @return an object that defines a scope where the given {@link StatsContext} will be set to the
+   *     current Context.
+   * @throws NullPointerException if statsContext is null.
+   */
+  public final NonThrowingCloseable withStatsContext(StatsContext statsContext) {
+    return ContextUtils.withStatsContext(checkNotNull(statsContext, "StatsContext"));
+  }
 }

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -44,8 +44,8 @@ public abstract class StatsContextFactory {
   /**
    * Get current StatsContext from current gRPC Context.
    *
-   * @return the current {@code StatsContext} from {@code io.grpc.Context}, or {@code null}
-   *     if there's no {@code StatsContext} associated with current {@code io.grpc.Context}.
+   * @return the current {@code StatsContext} from {@code io.grpc.Context}, or {@code null} if
+   *     there's no {@code StatsContext} associated with current {@code io.grpc.Context}.
    */
   @Nullable
   public final StatsContext getCurrentStatsContext() {
@@ -61,12 +61,48 @@ public abstract class StatsContextFactory {
    *
    * <p>Supports try-with-resource idiom.
    *
+   * <p>Example of usage:
+   *
+   * <pre>{@code
+   * // initialized by constructor or by calling Stats.getStatsContextFactory()
+   * private final StatsContextFactory statsCtxFactory;
+   * void doWork {
+   *   checkNotNull(statsCtxFactory, "statsCtxFactory");
+   *   // Construct a new StatsContext with required tags to be set into current context.
+   *   StatsContext statsCtx = statsCtxFactory.getDefault().with(tagKey, tagValue);
+   *   try (NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx)) {
+   *     doSomeOtherWork();  // Here "scopedStatsCtx" is the current StatsContext.
+   *   }
+   * }
+   * }</pre>
+   *
+   * <p>Prior to Java SE 7, you can use a finally block to ensure that a resource is closed
+   * regardless of whether the try statement completes normally or abruptly.
+   *
+   * <p>Example of usage prior to Java SE7:
+   *
+   * <pre>{@code
+   * // initialized by constructor or by calling Stats.getStatsContextFactory()
+   * private final StatsContextFactory statsCtxFactory;
+   * void doWork {
+   *   checkNotNull(statsCtxFactory, "statsCtxFactory");
+   *   // Construct a new StatsContext with required tags to be set into current context.
+   *   StatsContext statsCtx = statsCtxFactory.getDefault().with(tagKey, tagValue);
+   *   NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx);
+   *   try {
+   *     doSomeOtherWork();  // Here "scopedStatsCtx" is the current StatsContext.
+   *   } finally {
+   *     scopedStatsCtx.close();
+   *   }
+   * }
+   * }</pre>
+   *
    * @param statsContext The {@link StatsContext} to be set to the current Context.
    * @return an object that defines a scope where the given {@link StatsContext} will be set to the
    *     current Context.
    * @throws NullPointerException if statsContext is null.
    */
   public final NonThrowingCloseable withStatsContext(StatsContext statsContext) {
-    return ContextUtils.withStatsContext(checkNotNull(statsContext, "StatsContext"));
+    return ContextUtils.withStatsContext(checkNotNull(statsContext, "statsContext"));
   }
 }

--- a/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
+++ b/core/src/main/java/com/google/instrumentation/stats/StatsContextFactory.java
@@ -62,9 +62,9 @@ public abstract class StatsContextFactory {
    * <p>Example of usage:
    *
    * <pre>{@code
-   * private final StatsContextFactory statsCtxFactory = Stats.getStatsContextFactory();
+   * private final StatsContextFactory statsCtxFactory =
+   *     checkNotNull(Stats.getStatsContextFactory(), "statsCtxFactory");
    * void doWork() {
-   *   checkNotNull(statsCtxFactory, "statsCtxFactory");
    *   // Construct a new StatsContext with required tags to be set into current context.
    *   StatsContext statsCtx = statsCtxFactory.getCurrentStatsContext().with(tagKey, tagValue);
    *   try (NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx)) {
@@ -79,9 +79,9 @@ public abstract class StatsContextFactory {
    * <p>Example of usage prior to Java SE7:
    *
    * <pre>{@code
-   * private final StatsContextFactory statsCtxFactory = Stats.getStatsContextFactory();
+   * private final StatsContextFactory statsCtxFactory =
+   *     checkNotNull(Stats.getStatsContextFactory(), "statsCtxFactory");
    * void doWork() {
-   *   checkNotNull(statsCtxFactory, "statsCtxFactory");
    *   // Construct a new StatsContext with required tags to be set into current context.
    *   StatsContext statsCtx = statsCtxFactory.getCurrentStatsContext().with(tagKey, tagValue);
    *   NonThrowingCloseable scopedStatsCtx = statsCtxFactory.withStatsContext(statsCtx);

--- a/core/src/main/java/com/google/instrumentation/trace/Tracer.java
+++ b/core/src/main/java/com/google/instrumentation/trace/Tracer.java
@@ -105,9 +105,9 @@ public abstract class Tracer {
    *
    * <pre>{@code
    * private static Tracer tracer = Tracing.getTracer();
-   * void doWork {
+   * void doWork() {
    *   // Create a Span as a child of the current Span.
-   *   Span span = tracer.startSpan("my span");
+   *   Span span = tracer.spanBuilder("my span").startSpan();
    *   try (NonThrowingCloseable ws = tracer.withSpan(span)) {
    *     tracer.getCurrentSpan().addAnnotation("my annotation");
    *     doSomeOtherWork();  // Here "span" is the current Span.
@@ -123,9 +123,9 @@ public abstract class Tracer {
    *
    * <pre>{@code
    * private static Tracer tracer = Tracing.getTracer();
-   * void doWork {
+   * void doWork() {
    *   // Create a Span as a child of the current Span.
-   *   Span span = tracer.startSpan("my span");
+   *   Span span = tracer.spanBuilder("my span").startSpan();
    *   NonThrowingCloseable ws = tracer.withSpan(span);
    *   try {
    *     tracer.getCurrentSpan().addAnnotation("my annotation");

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
@@ -15,9 +15,11 @@ package com.google.instrumentation.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.instrumentation.common.NonThrowingCloseable;
 import com.google.instrumentation.common.SimpleEventQueue;
 import com.google.instrumentation.internal.TestClock;
 import com.google.io.base.VarInt;
+import io.grpc.Context;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,6 +43,8 @@ public class StatsContextFactoryTest {
       new StatsManagerImplBase(new SimpleEventQueue(), TestClock.create());
   private final StatsContextFactory factory = new StatsContextFactoryImpl(statsManager);
   private final HashMap<TagKey, TagValue> sampleTags = new HashMap<TagKey, TagValue>();
+  private final StatsContext statsContext = factory.getDefault()
+      .with(TagKey.create(KEY), TagValue.create(VALUE_STRING));
 
   public StatsContextFactoryTest() {
     sampleTags.put(
@@ -129,6 +133,64 @@ public class StatsContextFactoryTest {
   @Test(expected = IOException.class)
   public void testDeserializeWrongVersionId() throws Exception {
     testDeserialize(new ByteArrayInputStream(new byte[]{(byte) (StatsSerializer.VERSION_ID + 1)}));
+  }
+
+  @Test
+  public void testGetNullForCurrentStatsContextWhenNotSet() {
+    assertThat(factory.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testGetCurrentStatsContext() {
+    assertThat(factory.getCurrentStatsContext()).isNull();
+    Context origContext = Context.current().withValue(
+        ContextUtils.STATS_CONTEXT_KEY, statsContext)
+        .attach();
+    // Make sure context is detached even if test fails.
+    try {
+      assertThat(factory.getCurrentStatsContext()).isSameAs(statsContext);
+    } finally {
+      Context.current().detach(origContext);
+    }
+    assertThat(factory.getCurrentStatsContext()).isNull();
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testWithNullStatsContext() {
+    factory.withStatsContext(null);
+  }
+
+  @Test
+  public void testWithStatsContext() {
+    assertThat(factory.getCurrentStatsContext()).isNull();
+    NonThrowingCloseable scopedStatsCtx = factory.withStatsContext(statsContext);
+    try {
+      assertThat(factory.getCurrentStatsContext()).isEqualTo(statsContext);
+    } finally {
+      scopedStatsCtx.close();
+    }
+    assertThat(factory.getCurrentStatsContext()).isNull();
+  }
+
+  @Test
+  public void testWithStatsContextUsingWrap() {
+    Runnable runnable;
+    NonThrowingCloseable scopedStatsCtx = factory.withStatsContext(statsContext);
+    try {
+      assertThat(factory.getCurrentStatsContext()).isSameAs(statsContext);
+      runnable = Context.current().wrap(
+          new Runnable() {
+            @Override
+            public void run() {
+              assertThat(factory.getCurrentStatsContext()).isSameAs(statsContext);
+            }
+          });
+    } finally {
+      scopedStatsCtx.close();
+    }
+    assertThat(factory.getCurrentStatsContext()).isNull();
+    // When we run the runnable we will have the statsContext in the current Context.
+    runnable.run();
   }
 
   private StatsContext testDeserialize(InputStream inputStream)

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
@@ -195,7 +195,7 @@ public class StatsContextFactoryTest {
   }
 
   private StatsContext testDeserialize(InputStream inputStream)
-      throws IOException, IOException {
+      throws IOException {
     return factory.deserialize(inputStream);
   }
 

--- a/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/com/google/instrumentation/stats/StatsContextFactoryTest.java
@@ -43,6 +43,7 @@ public class StatsContextFactoryTest {
       new StatsManagerImplBase(new SimpleEventQueue(), TestClock.create());
   private final StatsContextFactory factory = new StatsContextFactoryImpl(statsManager);
   private final HashMap<TagKey, TagValue> sampleTags = new HashMap<TagKey, TagValue>();
+  private final StatsContext defaultCtx = factory.getDefault();
   private final StatsContext statsContext = factory.getDefault()
       .with(TagKey.create(KEY), TagValue.create(VALUE_STRING));
 
@@ -136,13 +137,13 @@ public class StatsContextFactoryTest {
   }
 
   @Test
-  public void testGetNullForCurrentStatsContextWhenNotSet() {
-    assertThat(factory.getCurrentStatsContext()).isNull();
+  public void testGetDefaultForCurrentStatsContextWhenNotSet() {
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
   }
 
   @Test
   public void testGetCurrentStatsContext() {
-    assertThat(factory.getCurrentStatsContext()).isNull();
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
     Context origContext = Context.current().withValue(
         ContextUtils.STATS_CONTEXT_KEY, statsContext)
         .attach();
@@ -152,7 +153,7 @@ public class StatsContextFactoryTest {
     } finally {
       Context.current().detach(origContext);
     }
-    assertThat(factory.getCurrentStatsContext()).isNull();
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
   }
 
   @Test(expected = NullPointerException.class)
@@ -162,14 +163,14 @@ public class StatsContextFactoryTest {
 
   @Test
   public void testWithStatsContext() {
-    assertThat(factory.getCurrentStatsContext()).isNull();
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
     NonThrowingCloseable scopedStatsCtx = factory.withStatsContext(statsContext);
     try {
       assertThat(factory.getCurrentStatsContext()).isEqualTo(statsContext);
     } finally {
       scopedStatsCtx.close();
     }
-    assertThat(factory.getCurrentStatsContext()).isNull();
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
   }
 
   @Test
@@ -188,7 +189,7 @@ public class StatsContextFactoryTest {
     } finally {
       scopedStatsCtx.close();
     }
-    assertThat(factory.getCurrentStatsContext()).isNull();
+    assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
     // When we run the runnable we will have the statsContext in the current Context.
     runnable.run();
   }


### PR DESCRIPTION
Expose the util methods in PR https://github.com/google/instrumentation-java/pull/299 to public APIs in StatsContextFactory. This is similar to [Tracer](https://github.com/google/instrumentation-java/blob/master/core/src/main/java/com/google/instrumentation/trace/Tracer.java#L91), except that currently we don't have no-op objects for Stats (Issue https://github.com/google/instrumentation-java/issues/215), and `getCurrentStatsContext()` may return null (vesus `getCurrentSpan()` returns a no-op). I may need to update `getCurrentStatsContext()` after we came to an agreement on that issue.

/cc @zhangkun83 