### PR TITLE
Disable Checkstyle's MissingSwitchDefault warning.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -76,7 +76,8 @@
         <module name="OneStatementPerLine"/>
         <module name="MultipleVariableDeclarations"/>
         <module name="ArrayTypeStyle"/>
-        <module name="MissingSwitchDefault"/>
+        <!-- This rule conflicts with Error Prone's exhaustiveness checking. -->
+	    <!-- <module name="MissingSwitchDefault"/> -->
         <module name="FallThrough"/>
         <module name="UpperEll"/>
         <module name="ModifierOrder"/>


### PR DESCRIPTION
This rule conflicts with Error Prone's exhaustiveness checking.  When all enum
cases are handled in a switch block, Error Prone doesn't allow a "default" case,
but Checkstyle always requires a "default" case.

______________________

I fixed the conflict this way because I thought the Error Prone warning was more useful.  Is that okay?

/cc @dinooliva @a-veitch 

EDIT: I needed this for #276.